### PR TITLE
fix: remove unnecessary mutable variable declarations in blockedmean.rs

### DIFF
--- a/src/prepare/blockedmean.rs
+++ b/src/prepare/blockedmean.rs
@@ -66,13 +66,13 @@ impl BlockedMean {
 
         for (x, y, p) in grayscale.enumerate_pixels() {
             let coords = as_block_coords(ImageCoord(x), ImageCoord(y), self.block_size);
-            let mut stats = &mut blocks[to_index(coords, block_width)];
+            let stats = &mut blocks[to_index(coords, block_width)];
 
             stats.total += u64::from(p.channels()[0]);
             stats.count += 1;
         }
 
-        for mut stat in &mut blocks {
+        for stat in &mut blocks {
             stat.mean = stat.total as f64 / stat.count as f64;
         }
 


### PR DESCRIPTION
## Summary
This PR removes unnecessary mutable variable declarations in `src/prepare/blockedmean.rs` that were causing compiler warnings.

## Changes
- Line 69: Changed `let mut stats = &mut blocks[...]` to `let stats = &mut blocks[...]`
- Line 75: Changed `for mut stat in &mut blocks` to `for stat in &mut blocks`

These variables don't need to be declared as mutable since we're already borrowing mutably from the collection.

## Testing
✅ `cargo build` - No more warnings about unnecessary mutable variables
✅ `cargo test` - All 14 integration tests + 6 doc tests pass
✅ `cargo clippy` - No new warnings introduced

## Impact
This is a code quality improvement that eliminates 2 compiler warnings without changing any functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)