### PR TITLE
Fix clippy warnings and improve code quality

### DIFF
--- a/clippy_output.txt
+++ b/clippy_output.txt
@@ -1,0 +1,2672 @@
+    Updating crates.io index
+     Locking 59 packages to latest compatible versions
+      Adding image v0.23.14 (available: v0.25.6)
+ Downloading crates ...
+  Downloaded addr2line v0.24.2
+  Downloaded adler32 v1.2.0
+  Downloaded byteorder v1.5.0
+  Downloaded autocfg v1.5.0
+  Downloaded bitflags v1.3.2
+  Downloaded unicode-xid v0.2.6
+  Downloaded either v1.15.0
+  Downloaded quote v1.0.40
+  Downloaded semver v0.1.20
+  Downloaded weezl v0.1.10
+  Downloaded rayon-core v1.13.0
+  Downloaded miniz_oxide v0.8.9
+  Downloaded memchr v2.7.5
+  Downloaded rayon v1.11.0
+  Downloaded deflate v0.8.6
+  Downloaded miniz_oxide v0.4.4
+  Downloaded miniz_oxide v0.3.7
+  Downloaded log v0.4.27
+  Downloaded crossbeam-utils v0.8.21
+  Downloaded syn v1.0.109
+  Downloaded image v0.23.14
+  Downloaded gimli v0.31.1
+  Downloaded jpeg-decoder v0.1.22
+  Downloaded unicode-ident v1.0.18
+  Downloaded png v0.16.8
+  Downloaded object v0.36.7
+  Downloaded crossbeam-epoch v0.9.18
+  Downloaded backtrace v0.3.75
+  Downloaded rustc-demangle v0.1.26
+  Downloaded proc-macro2 v1.0.101
+  Downloaded num-traits v0.2.19
+  Downloaded num-rational v0.3.2
+  Downloaded num-integer v0.1.46
+  Downloaded failure v0.1.8
+  Downloaded crc32fast v1.5.0
+  Downloaded color_quant v1.1.0
+  Downloaded newtype_derive v0.1.6
+  Downloaded failure_derive v0.1.8
+  Downloaded crossbeam-deque v0.8.6
+  Downloaded cfg-if v1.0.3
+  Downloaded bytemuck v1.23.2
+  Downloaded synstructure v0.12.6
+  Downloaded scoped_threadpool v0.1.9
+  Downloaded gif v0.11.4
+  Downloaded rustc_version v0.1.7
+  Downloaded num-iter v0.1.45
+  Downloaded adler2 v2.0.1
+  Downloaded adler v1.0.2
+  Downloaded libc v0.2.175
+  Downloaded tiff v0.6.1
+   Compiling autocfg v1.5.0
+   Compiling crossbeam-utils v0.8.21
+   Compiling proc-macro2 v1.0.101
+   Compiling num-traits v0.2.19
+    Checking crossbeam-epoch v0.9.18
+   Compiling rayon-core v1.13.0
+   Compiling unicode-ident v1.0.18
+    Checking crossbeam-deque v0.8.6
+   Compiling syn v1.0.109
+    Checking cfg-if v1.0.3
+   Compiling quote v1.0.40
+   Compiling miniz_oxide v0.4.4
+   Compiling semver v0.1.20
+   Compiling crc32fast v1.5.0
+   Compiling libc v0.2.175
+    Checking adler32 v1.2.0
+    Checking either v1.15.0
+   Compiling object v0.36.7
+    Checking rayon v1.11.0
+   Compiling rustc_version v0.1.7
+    Checking num-integer v0.1.46
+   Compiling num-rational v0.3.2
+   Compiling unicode-xid v0.2.6
+    Checking weezl v0.1.10
+    Checking adler v1.0.2
+    Checking byteorder v1.5.0
+    Checking gimli v0.31.1
+    Checking adler2 v2.0.1
+    Checking memchr v2.7.5
+   Compiling failure_derive v0.1.8
+    Checking addr2line v0.24.2
+    Checking miniz_oxide v0.8.9
+    Checking deflate v0.8.6
+   Compiling synstructure v0.12.6
+    Checking jpeg-decoder v0.1.22
+   Compiling newtype_derive v0.1.6
+    Checking miniz_oxide v0.3.7
+    Checking color_quant v1.1.0
+    Checking bitflags v1.3.2
+    Checking rustc-demangle v0.1.26
+    Checking png v0.16.8
+    Checking backtrace v0.3.75
+    Checking gif v0.11.4
+    Checking tiff v0.6.1
+    Checking num-iter v0.1.45
+    Checking bytemuck v1.23.2
+    Checking scoped_threadpool v0.1.9
+    Checking image v0.23.14
+    Checking failure v0.1.8
+    Checking log v0.4.27
+    Checking bardecoder v0.3.1 (/root/repo)
+error: empty line after doc comment
+  --> src/decode/mod.rs:39:1
+   |
+39 | / /// [`Decoder`]: ../struct.Decoder.html
+40 | |
+   | |_^
+41 |   pub trait Decode<DATA, RESULT, ERROR>
+   |   ---------------- the comment documents this trait
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments
+note: the lint level is defined here
+  --> src/lib.rs:7:48
+   |
+7  | #![cfg_attr(feature = "fail-on-warnings", deny(warnings))]
+   |                                                ^^^^^^^^
+   = note: `#[deny(clippy::empty_line_after_doc_comments)]` implied by `#[deny(warnings)]`
+   = help: if the empty line is unintentional, remove it
+
+error: binding's name is too similar to existing binding
+   --> src/extract/qr/mod.rs:386:46
+    |
+386 |     fn new(dx: Delta, ddx: Delta, dy: Delta, ddy: Delta) -> Perspective {
+    |                                              ^^^
+    |
+note: existing binding defined here
+   --> src/extract/qr/mod.rs:386:23
+    |
+386 |     fn new(dx: Delta, ddx: Delta, dy: Delta, ddy: Delta) -> Perspective {
+    |                       ^^^
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#similar_names
+    = note: `#[deny(clippy::similar_names)]` implied by `#[deny(warnings)]`
+
+error: use of deprecated method `image::DynamicImage::to_rgb`: replaced by `to_rgb8`
+   --> src/detect/linescan.rs:129:70
+    |
+129 |             let mut img = DynamicImage::ImageLuma8(prepared.clone()).to_rgb();
+    |                                                                      ^^^^^^
+    |
+    = note: `#[deny(deprecated)]` implied by `#[deny(warnings)]`
+
+error: use of deprecated method `image::DynamicImage::to_rgb`: replaced by `to_rgb8`
+  --> src/extract/qr/mod.rs:48:66
+   |
+48 |         let mut img = DynamicImage::ImageLuma8(prepared.clone()).to_rgb();
+   |                                                                  ^^^^^^
+
+error: use of deprecated method `image::DynamicImage::to_rgb`: replaced by `to_rgb8`
+   --> src/extract/qr/mod.rs:228:66
+    |
+228 |         let mut img = DynamicImage::ImageLuma8(prepared.clone()).to_rgb();
+    |                                                                  ^^^^^^
+
+error: use of deprecated method `image::DynamicImage::to_rgb`: replaced by `to_rgb8`
+   --> src/extract/qr/mod.rs:289:66
+    |
+289 |         let mut img = DynamicImage::ImageLuma8(prepared.clone()).to_rgb();
+    |                                                                  ^^^^^^
+
+error: item in documentation is missing backticks
+  --> src/decoder.rs:14:20
+   |
+14 | /// Error type for DecoderBuilder
+   |                    ^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+   = note: `#[deny(clippy::doc_markdown)]` implied by `#[deny(warnings)]`
+help: try
+   |
+14 - /// Error type for DecoderBuilder
+14 + /// Error type for `DecoderBuilder`
+   |
+
+error: item in documentation is missing backticks
+  --> src/decoder.rs:71:16
+   |
+71 | /// * prepare: BlockedMean
+   |                ^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+   |
+71 - /// * prepare: BlockedMean
+71 + /// * prepare: `BlockedMean`
+   |
+
+error: item in documentation is missing backticks
+  --> src/decoder.rs:72:15
+   |
+72 | /// * detect: LineScan
+   |               ^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+   |
+72 - /// * detect: LineScan
+72 + /// * detect: `LineScan`
+   |
+
+error: item in documentation is missing backticks
+  --> src/decoder.rs:73:16
+   |
+73 | /// * extract: QRExtractor
+   |                ^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+   |
+73 - /// * extract: QRExtractor
+73 + /// * extract: `QRExtractor`
+   |
+
+error: item in documentation is missing backticks
+  --> src/decoder.rs:74:15
+   |
+74 | /// * decode: QRDecoder
+   |               ^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+   |
+74 - /// * decode: QRDecoder
+74 + /// * decode: `QRDecoder`
+   |
+
+error: this function could have a `#[must_use]` attribute
+  --> src/decoder.rs:82:1
+   |
+82 | pub fn default_decoder() -> Decoder<DynamicImage, GrayImage, String> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn default_decoder() -> Decoder<DynamicImage, GrayImage, String>`
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate
+   = note: `#[deny(clippy::must_use_candidate)]` implied by `#[deny(warnings)]`
+
+error: item in documentation is missing backticks
+  --> src/decoder.rs:92:16
+   |
+92 | /// * prepare: BlockedMean
+   |                ^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+   |
+92 - /// * prepare: BlockedMean
+92 + /// * prepare: `BlockedMean`
+   |
+
+error: item in documentation is missing backticks
+  --> src/decoder.rs:93:15
+   |
+93 | /// * detect: LineScan
+   |               ^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+   |
+93 - /// * detect: LineScan
+93 + /// * detect: `LineScan`
+   |
+
+error: item in documentation is missing backticks
+  --> src/decoder.rs:94:16
+   |
+94 | /// * extract: QRExtractor
+   |                ^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+   |
+94 - /// * extract: QRExtractor
+94 + /// * extract: `QRExtractor`
+   |
+
+error: item in documentation is missing backticks
+  --> src/decoder.rs:95:15
+   |
+95 | /// * decode: QRDecoderWithInfo
+   |               ^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+   |
+95 - /// * decode: QRDecoderWithInfo
+95 + /// * decode: `QRDecoderWithInfo`
+   |
+
+error: this function could have a `#[must_use]` attribute
+   --> src/decoder.rs:103:1
+    |
+103 | pub fn default_decoder_with_info() -> Decoder<DynamicImage, GrayImage, (String, QRInfo)> {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn default_decoder_with_info() -> Decoder<DynamicImage, GrayImage, (String, QRInfo)>`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate
+
+error: this method could have a `#[must_use]` attribute
+   --> src/decoder.rs:125:5
+    |
+125 |     pub fn new() -> DecoderBuilder<IMG, PREPD, RESULT> {
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn new() -> DecoderBuilder<IMG, PREPD, RESULT>`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate
+
+error: item in documentation is missing backticks
+   --> src/decoder.rs:182:22
+    |
+182 | /// Create a default DecoderBuilder
+    |                      ^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+    |
+182 - /// Create a default DecoderBuilder
+182 + /// Create a default `DecoderBuilder`
+    |
+
+error: item in documentation is missing backticks
+   --> src/decoder.rs:186:16
+    |
+186 | /// * prepare: BlockedMean
+    |                ^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+    |
+186 - /// * prepare: BlockedMean
+186 + /// * prepare: `BlockedMean`
+    |
+
+error: item in documentation is missing backticks
+   --> src/decoder.rs:187:15
+    |
+187 | /// * locate: LineScan
+    |               ^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+    |
+187 - /// * locate: LineScan
+187 + /// * locate: `LineScan`
+    |
+
+error: item in documentation is missing backticks
+   --> src/decoder.rs:188:16
+    |
+188 | /// * extract: QRExtractor
+    |                ^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+    |
+188 - /// * extract: QRExtractor
+188 + /// * extract: `QRExtractor`
+    |
+
+error: item in documentation is missing backticks
+   --> src/decoder.rs:189:15
+    |
+189 | /// * decode: QRDecoder
+    |               ^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+    |
+189 - /// * decode: QRDecoder
+189 + /// * decode: `QRDecoder`
+    |
+
+error: this function could have a `#[must_use]` attribute
+   --> src/decoder.rs:192:1
+    |
+192 | pub fn default_builder() -> DecoderBuilder<DynamicImage, GrayImage, String> {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn default_builder() -> DecoderBuilder<DynamicImage, GrayImage, String>`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate
+
+error: item in documentation is missing backticks
+   --> src/decoder.rs:202:22
+    |
+202 | /// Create a default DecoderBuilder that also returns information about the decoded QR Code
+    |                      ^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+    |
+202 - /// Create a default DecoderBuilder that also returns information about the decoded QR Code
+202 + /// Create a default `DecoderBuilder` that also returns information about the decoded QR Code
+    |
+
+error: item in documentation is missing backticks
+   --> src/decoder.rs:206:16
+    |
+206 | /// * prepare: BlockedMean
+    |                ^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+    |
+206 - /// * prepare: BlockedMean
+206 + /// * prepare: `BlockedMean`
+    |
+
+error: item in documentation is missing backticks
+   --> src/decoder.rs:207:15
+    |
+207 | /// * locate: LineScan
+    |               ^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+    |
+207 - /// * locate: LineScan
+207 + /// * locate: `LineScan`
+    |
+
+error: item in documentation is missing backticks
+   --> src/decoder.rs:208:16
+    |
+208 | /// * extract: QRExtractor
+    |                ^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+    |
+208 - /// * extract: QRExtractor
+208 + /// * extract: `QRExtractor`
+    |
+
+error: item in documentation is missing backticks
+   --> src/decoder.rs:209:15
+    |
+209 | /// * decode: QRDecoderWithInfo
+    |               ^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+    |
+209 - /// * decode: QRDecoderWithInfo
+209 + /// * decode: `QRDecoderWithInfo`
+    |
+
+error: this function could have a `#[must_use]` attribute
+   --> src/decoder.rs:212:1
+    |
+212 | pub fn default_builder_with_info() -> DecoderBuilder<DynamicImage, GrayImage, (String, QRInfo)> {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn default_builder_with_info() -> DecoderBuilder<DynamicImage, GrayImage, (String, QRInfo)>`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate
+
+error: consider adding a `;` to the last statement for consistent formatting
+  --> src/decode/qr/blocks.rs:33:13
+   |
+33 |             x = 5
+   |             ^^^^^ help: add a `;` here: `x = 5;`
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#semicolon_if_nothing_returned
+   = note: `#[deny(clippy::semicolon_if_nothing_returned)]` implied by `#[deny(warnings)]`
+
+error: this operation has no effect
+   --> src/decode/qr/blocks.rs:122:30
+    |
+122 |     if coord >= 4 && coord - 4 % 6 <= 4 {
+    |                              ^^^^^ help: consider reducing it to: `4`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#identity_op
+    = note: `#[deny(clippy::identity_op)]` implied by `#[deny(warnings)]`
+
+error: these match arms have identical bodies
+   --> src/decode/qr/blocks.rs:152:9
+    |
+152 |         9 => Ok(AlignmentLocation::new(26, 20)),
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+157 |         14 => Ok(AlignmentLocation::new(26, 20)),
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is unintentional make the arms return different values
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_same_arms
+    = note: `#[deny(clippy::match_same_arms)]` implied by `#[deny(warnings)]`
+help: otherwise merge the patterns into a single arm
+    |
+152 ~         9 | 14 => Ok(AlignmentLocation::new(26, 20)),
+153 |         10 => Ok(AlignmentLocation::new(28, 22)),
+...
+156 |         13 => Ok(AlignmentLocation::new(34, 28)),
+157 ~         15 => Ok(AlignmentLocation::new(26, 22)),
+    |
+
+error: these match arms have identical bodies
+   --> src/decode/qr/blocks.rs:154:9
+    |
+154 |         11 => Ok(AlignmentLocation::new(30, 24)),
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+160 |         17 => Ok(AlignmentLocation::new(30, 24)),
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is unintentional make the arms return different values
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_same_arms
+help: otherwise merge the patterns into a single arm
+    |
+154 ~         11 | 17 => Ok(AlignmentLocation::new(30, 24)),
+155 |         12 => Ok(AlignmentLocation::new(32, 26)),
+...
+159 |         16 => Ok(AlignmentLocation::new(26, 24)),
+160 ~         18 => Ok(AlignmentLocation::new(30, 26)),
+    |
+
+error: these match arms have identical bodies
+   --> src/decode/qr/blocks.rs:155:9
+    |
+155 |         12 => Ok(AlignmentLocation::new(32, 26)),
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+164 |         25 => Ok(AlignmentLocation::new(32, 26)),
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is unintentional make the arms return different values
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_same_arms
+help: otherwise merge the patterns into a single arm
+    |
+155 ~         12 | 25 => Ok(AlignmentLocation::new(32, 26)),
+156 |         13 => Ok(AlignmentLocation::new(34, 28)),
+...
+163 |         20 => Ok(AlignmentLocation::new(34, 28)),
+164 ~         36 => Ok(AlignmentLocation::new(24, 26)),
+    |
+
+error: these match arms have identical bodies
+   --> src/decode/qr/blocks.rs:156:9
+    |
+156 |         13 => Ok(AlignmentLocation::new(34, 28)),
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+163 |         20 => Ok(AlignmentLocation::new(34, 28)),
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is unintentional make the arms return different values
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_same_arms
+help: otherwise merge the patterns into a single arm
+    |
+156 ~         13 | 20 => Ok(AlignmentLocation::new(34, 28)),
+157 |         14 => Ok(AlignmentLocation::new(26, 20)),
+...
+162 |         19 => Ok(AlignmentLocation::new(30, 28)),
+163 ~         25 => Ok(AlignmentLocation::new(32, 26)),
+    |
+
+error: these match arms have identical bodies
+   --> src/decode/qr/blocks.rs:162:9
+    |
+162 |         19 => Ok(AlignmentLocation::new(30, 28)),
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+166 |         40 => Ok(AlignmentLocation::new(30, 28)),
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is unintentional make the arms return different values
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_same_arms
+help: otherwise merge the patterns into a single arm
+    |
+162 ~         19 | 40 => Ok(AlignmentLocation::new(30, 28)),
+163 |         20 => Ok(AlignmentLocation::new(34, 28)),
+164 |         25 => Ok(AlignmentLocation::new(32, 26)),
+165 |         36 => Ok(AlignmentLocation::new(24, 26)),
+166 ~         _ => Err(QRError {
+    |
+
+error: variables can be used directly in the `format!` string
+   --> src/decode/qr/blocks.rs:168:18
+    |
+168 |             msg: format!("Unknown version {}", version),
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+    = note: `#[deny(clippy::uninlined_format_args)]` implied by `#[deny(warnings)]`
+help: change this to
+    |
+168 -             msg: format!("Unknown version {}", version),
+168 +             msg: format!("Unknown version {version}"),
+    |
+
+error: field name starts with the struct's name
+   --> src/decode/qr/blocks.rs:187:5
+    |
+187 |     blocks: Vec<Vec<u8>>,
+    |     ^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#struct_field_names
+    = note: `#[deny(clippy::struct_field_names)]` implied by `#[deny(warnings)]`
+
+error: field name ends with the struct's name
+   --> src/decode/qr/blocks.rs:192:5
+    |
+192 |     data_blocks: bool,
+    |     ^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#struct_field_names
+
+error: this expression creates a reference which is immediately dereferenced by the compiler
+  --> src/decode/qr/correct.rs:59:42
+   |
+59 |         syndromes[i as usize] = syndrome(&block, EXP8[i as usize]);
+   |                                          ^^^^^^ help: change this to: `block`
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
+   = note: `#[deny(clippy::needless_borrow)]` implied by `#[deny(warnings)]`
+
+error: variables can be used directly in the `format!` string
+   --> src/decode/qr/correct.rs:106:13
+    |
+106 |             debug!("LOC {:?} {} ", exp, i);
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+106 -             debug!("LOC {:?} {} ", exp, i);
+106 +             debug!("LOC {exp:?} {i} ");
+    |
+
+error: variables can be used directly in the `format!` string
+   --> src/decode/qr/correct.rs:111:5
+    |
+111 |     debug!("LOCS {:?}", locs);
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+111 -     debug!("LOCS {:?}", locs);
+111 +     debug!("LOCS {locs:?}");
+    |
+
+error: casting to the same type is unnecessary (`usize` -> `usize`)
+   --> src/decode/qr/correct.rs:120:34
+    |
+120 |             eq[i][j] = EXP8[(i * locs[j] as usize) % 255];
+    |                                  ^^^^^^^^^^^^^^^^ help: try: `locs[j]`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
+    = note: `#[deny(clippy::unnecessary_cast)]` implied by `#[deny(warnings)]`
+
+error: casting to the same type is unnecessary (`usize` -> `usize`)
+   --> src/decode/qr/correct.rs:133:18
+    |
+133 |     let num_eq = eq.len() as usize;
+    |                  ^^^^^^^^^^^^^^^^^ help: try: `eq.len()`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
+
+error: variables can be used directly in the `format!` string
+  --> src/decode/qr/data.rs:16:26
+   |
+16 |                     msg: format!("Mode {:04b} not yet implemented.", mode),
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+16 -                     msg: format!("Mode {:04b} not yet implemented.", mode),
+16 +                     msg: format!("Mode {mode:04b} not yet implemented."),
+   |
+
+error: variables can be used directly in the `format!` string
+  --> src/decode/qr/data.rs:32:22
+   |
+32 |                 msg: format!("Unknown version {}", version),
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+32 -                 msg: format!("Unknown version {}", version),
+32 +                 msg: format!("Unknown version {version}"),
+   |
+
+error: variables can be used directly in the `format!` string
+  --> src/decode/qr/data.rs:40:18
+   |
+40 |             msg: format!("Could not read {} bits for numeric length", length_bits),
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+40 -             msg: format!("Could not read {} bits for numeric length", length_bits),
+40 +             msg: format!("Could not read {length_bits} bits for numeric length"),
+   |
+
+error: `format!(..)` appended to existing `String`
+  --> src/decode/qr/data.rs:49:13
+   |
+49 |             result.push_str(&format!("{:03}", digits));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using `write!` to avoid the extra allocation
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string
+   = note: `#[deny(clippy::format_push_string)]` implied by `#[deny(warnings)]`
+
+error: variables can be used directly in the `format!` string
+  --> src/decode/qr/data.rs:49:30
+   |
+49 |             result.push_str(&format!("{:03}", digits));
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+49 -             result.push_str(&format!("{:03}", digits));
+49 +             result.push_str(&format!("{digits:03}"));
+   |
+
+error: `format!(..)` appended to existing `String`
+  --> src/decode/qr/data.rs:57:13
+   |
+57 |             result.push_str(&format!("{:02}", digits));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using `write!` to avoid the extra allocation
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string
+
+error: variables can be used directly in the `format!` string
+  --> src/decode/qr/data.rs:57:30
+   |
+57 |             result.push_str(&format!("{:02}", digits));
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+57 -             result.push_str(&format!("{:02}", digits));
+57 +             result.push_str(&format!("{digits:02}"));
+   |
+
+error: `format!(..)` appended to existing `String`
+  --> src/decode/qr/data.rs:64:13
+   |
+64 |             result.push_str(&format!("{:01}", digits));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using `write!` to avoid the extra allocation
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string
+
+error: variables can be used directly in the `format!` string
+  --> src/decode/qr/data.rs:64:30
+   |
+64 |             result.push_str(&format!("{:01}", digits));
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+64 -             result.push_str(&format!("{:01}", digits));
+64 +             result.push_str(&format!("{digits:01}"));
+   |
+
+error: variables can be used directly in the `format!` string
+  --> src/decode/qr/data.rs:70:5
+   |
+70 |     debug!("NUMERIC {:?}", result);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+70 -     debug!("NUMERIC {:?}", result);
+70 +     debug!("NUMERIC {result:?}");
+   |
+
+error: variables can be used directly in the `format!` string
+  --> src/decode/qr/data.rs:88:22
+   |
+88 |                 msg: format!("Unknown version {}", version),
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+88 -                 msg: format!("Unknown version {}", version),
+88 +                 msg: format!("Unknown version {version}"),
+   |
+
+error: variables can be used directly in the `format!` string
+  --> src/decode/qr/data.rs:96:18
+   |
+96 |               msg: format!(
+   |  __________________^
+97 | |                 "Could not read {} bits for alphanumeric length",
+98 | |                 length_bits
+99 | |             ),
+   | |_____________^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+
+error: variables can be used directly in the `format!` string
+   --> src/decode/qr/data.rs:123:5
+    |
+123 |     debug!("ALPHANUMERIC {:?}", result);
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+123 -     debug!("ALPHANUMERIC {:?}", result);
+123 +     debug!("ALPHANUMERIC {result:?}");
+    |
+
+error: these match arms have identical bodies
+   --> src/decode/qr/data.rs:131:9
+    |
+131 |         10..=26 => 16,
+    |         ^^^^^^^^^^^^^
+132 |         27..=40 => 16,
+    |         ^^^^^^^^^^^^^
+    |
+    = help: if this is unintentional make the arms return different values
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_same_arms
+help: otherwise merge the patterns into a single arm
+    |
+131 ~         10..=26 | 27..=40 => 16,
+132 ~         _ => {
+    |
+
+error: variables can be used directly in the `format!` string
+   --> src/decode/qr/data.rs:135:22
+    |
+135 |                 msg: format!("Unknown version {}", version),
+    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+135 -                 msg: format!("Unknown version {}", version),
+135 +                 msg: format!("Unknown version {version}"),
+    |
+
+error: variables can be used directly in the `format!` string
+   --> src/decode/qr/data.rs:143:18
+    |
+143 |               msg: format!(
+    |  __________________^
+144 | |                 "Could not read {} bits for alphanumeric length",
+145 | |                 length_bits
+146 | |             ),
+    | |_____________^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+
+error: variables can be used directly in the `format!` string
+   --> src/decode/qr/data.rs:156:5
+    |
+156 |     debug!("EIGHT BIT RAW {:?}", result);
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+156 -     debug!("EIGHT BIT RAW {:?}", result);
+156 +     debug!("EIGHT BIT RAW {result:?}");
+    |
+
+error: variables can be used directly in the `format!` string
+   --> src/decode/qr/data.rs:169:9
+    |
+169 |         debug!("EIGHT BIT AS UTF-8 {:?}", utf8);
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+169 -         debug!("EIGHT BIT AS UTF-8 {:?}", utf8);
+169 +         debug!("EIGHT BIT AS UTF-8 {utf8:?}");
+    |
+
+error: variables can be used directly in the `format!` string
+   --> src/decode/qr/data.rs:176:9
+    |
+176 |         debug!("EIGHT BIT AS ISO 8859-1 {:?}", iso88591);
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+176 -         debug!("EIGHT BIT AS ISO 8859-1 {:?}", iso88591);
+176 +         debug!("EIGHT BIT AS ISO 8859-1 {iso88591:?}");
+    |
+
+error: variables can be used directly in the `format!` string
+   --> src/decode/qr/data.rs:187:18
+    |
+187 |             msg: format!("Could not read {} bits", bits),
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+187 -             msg: format!("Could not read {} bits", bits),
+187 +             msg: format!("Could not read {bits} bits"),
+    |
+
+error: variables can be used directly in the `format!` string
+   --> src/decode/qr/data.rs:196:18
+    |
+196 |             msg: format!("Could not read {} bits", bits),
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+196 -             msg: format!("Could not read {} bits", bits),
+196 +             msg: format!("Could not read {bits} bits"),
+    |
+
+error: item in documentation is missing backticks
+  --> src/decode/qr/decoder.rs:20:25
+   |
+20 |     /// Construct a new QRDecoder
+   |                         ^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+   |
+20 -     /// Construct a new QRDecoder
+20 +     /// Construct a new `QRDecoder`
+   |
+
+error: this method could have a `#[must_use]` attribute
+  --> src/decode/qr/decoder.rs:21:5
+   |
+21 |     pub fn new() -> QRDecoder {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn new() -> QRDecoder`
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate
+
+error: item in documentation is missing backticks
+  --> src/decode/qr/decoder.rs:53:27
+   |
+53 | /// Functions the same as QRDecoder, apart from also returning some information about the decoded QR Code.
+   |                           ^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+   |
+53 - /// Functions the same as QRDecoder, apart from also returning some information about the decoded QR Code.
+53 + /// Functions the same as `QRDecoder`, apart from also returning some information about the decoded QR Code.
+   |
+
+error: item in documentation is missing backticks
+  --> src/decode/qr/decoder.rs:57:25
+   |
+57 |     /// Construct a new QRDecoder
+   |                         ^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+   |
+57 -     /// Construct a new QRDecoder
+57 +     /// Construct a new `QRDecoder`
+   |
+
+error: this method could have a `#[must_use]` attribute
+  --> src/decode/qr/decoder.rs:58:5
+   |
+58 |     pub fn new() -> QRDecoderWithInfo {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn new() -> QRDecoderWithInfo`
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate
+
+error: casting `usize` to `u32` may truncate the value on targets with 64-bit wide pointers
+  --> src/decode/qr/decoder.rs:85:26
+   |
+85 |         let total_data = (all_blocks.len() as u32) * 8;
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+   = note: `#[deny(clippy::cast_possible_truncation)]` implied by `#[deny(warnings)]`
+help: ... or use `try_from` and handle the error accordingly
+   |
+85 -         let total_data = (all_blocks.len() as u32) * 8;
+85 +         let total_data = u32::try_from(all_blocks.len()) * 8;
+   |
+
+error: variables can be used directly in the `format!` string
+   --> src/decode/qr/format.rs:144:5
+    |
+144 |     debug!("MASK {:03b}", bytes);
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+144 -     debug!("MASK {:03b}", bytes);
+144 +     debug!("MASK {bytes:03b}");
+    |
+
+error: this function's return value is unnecessarily wrapped by `Option`
+   --> src/decode/qr/format.rs:160:1
+    |
+160 | fn qrmask(mask: Box<Mask>) -> Option<Box<QRMask>> {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_wraps
+    = note: `#[deny(clippy::unnecessary_wraps)]` implied by `#[deny(warnings)]`
+help: remove `Option` from the return type...
+    |
+160 - fn qrmask(mask: Box<Mask>) -> Option<Box<QRMask>> {
+160 + fn qrmask(mask: Box<Mask>) -> std::boxed::Box<(dyn for<'a> std::ops::Fn(&'a util::qr::QRData, u32, u32) -> u8 + 'static)> {
+    |
+help: ...and then remove the surrounding `Some()` from returning expressions
+    |
+161 ~     Box::new(move |q: &QRData, i: u32, j: u32| {
+162 +         q[[i, j]] ^ (if mask(i, j) { 1 } else { 0 })
+163 +     })
+    |
+
+error: boolean to int conversion using if
+   --> src/decode/qr/format.rs:162:21
+    |
+162 |         q[[i, j]] ^ (if mask(i, j) { 1 } else { 0 })
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `u8::from(mask(i, j))`
+    |
+    = note: `mask(i, j) as u8` or `mask(i, j).into()` can also be valid options
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_to_int_with_if
+    = note: `#[deny(clippy::bool_to_int_with_if)]` implied by `#[deny(warnings)]`
+
+error: casting `i16` to `usize` may lose the sign of the value
+  --> src/decode/qr/galois.rs:55:14
+   |
+55 |         EXP8[(diff % 255) as usize]
+   |              ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+   = note: `#[deny(clippy::cast_sign_loss)]` implied by `#[deny(warnings)]`
+
+error: casting `i16` to `usize` may lose the sign of the value
+   --> src/decode/qr/galois.rs:107:14
+    |
+107 |         EXP4[diff as usize]
+    |              ^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: this function has too many lines (559/100)
+   --> src/decode/qr/mod.rs:31:1
+    |
+31  | / pub fn block_info(version: u32, level: &ECLevel) -> Result<Vec<BlockInfo>, QRError> {
+32  | |     let block_info = match (version, level) {
+33  | |         // Version 1
+34  | |         (1, ECLevel::LOW) => Ok(vec![BlockInfo::new(1, 26, 19, 2)]),
+...   |
+673 | |     Ok(bi_unwound)
+674 | | }
+    | |_^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_many_lines
+    = note: `#[deny(clippy::too_many_lines)]` implied by `#[deny(warnings)]`
+
+error: variables can be used directly in the `format!` string
+   --> src/decode/qr/mod.rs:658:18
+    |
+658 |               msg: format!(
+    |  __________________^
+659 | |                 "Unknown combination of version {} and level {:?}",
+660 | |                 version, level
+661 | |             ),
+    | |_____________^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+
+error: docs for function returning `Result` missing `# Errors` section
+  --> src/decode/mod.rs:46:5
+   |
+46 |     fn decode(&self, data: Result<DATA, ERROR>) -> Result<RESULT, ERROR>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc
+   = note: `#[deny(clippy::missing_errors_doc)]` implied by `#[deny(warnings)]`
+
+error: item in documentation is missing backticks
+  --> src/detect/linescan.rs:27:24
+   |
+27 |     /// Constuct a new LineScan
+   |                        ^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+   |
+27 -     /// Constuct a new LineScan
+27 +     /// Constuct a new `LineScan`
+   |
+
+error: this method could have a `#[must_use]` attribute
+  --> src/detect/linescan.rs:28:5
+   |
+28 |     pub fn new() -> LineScan {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn new() -> LineScan`
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate
+
+error: this function has too many lines (120/100)
+   --> src/detect/linescan.rs:36:5
+    |
+36  | /     fn detect(&self, prepared: &GrayImage) -> Vec<Location> {
+37  | |         // The order of refinement is important.
+38  | |         // The candidate is found in horizontal direction, so the first refinement is vertical
+39  | |         let refine_func: Vec<(Box<Refine>, f64, f64, bool)> = vec![
+...   |
+204 | |         locations
+205 | |     }
+    | |_____^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_many_lines
+
+error: this expression creates a reference which is immediately dereferenced by the compiler
+  --> src/detect/linescan.rs:95:40
+   |
+95 |                 let vert = refine_func(&self, prepared, &finder, module_size);
+   |                                        ^^^^^ help: change this to: `self`
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
+
+error: variables can be used directly in the `format!` string
+   --> src/detect/linescan.rs:123:9
+    |
+123 |         debug!("Candidate QR Locators {:#?}", candidates);
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+123 -         debug!("Candidate QR Locators {:#?}", candidates);
+123 +         debug!("Candidate QR Locators {candidates:#?}");
+    |
+
+error: it is more concise to loop over references to containers instead of using explicit iteration methods
+   --> src/detect/linescan.rs:131:22
+    |
+131 |             for c in candidates.iter() {
+    |                      ^^^^^^^^^^^^^^^^^ help: to write this more concisely, try: `&candidates`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_iter_loop
+    = note: `#[deny(clippy::explicit_iter_loop)]` implied by `#[deny(warnings)]`
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/detect/linescan.rs:133:31
+    |
+133 |                 let x_start = (loc.x - 3.5 * c.module_size).max(0.0_f64) as u32;
+    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/detect/linescan.rs:133:31
+    |
+133 |                 let x_start = (loc.x - 3.5 * c.module_size).max(0.0_f64) as u32;
+    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/detect/linescan.rs:134:53
+    |
+134 |                 let x_end = min(img.dimensions().0, (loc.x + 3.5 * c.module_size) as u32);
+    |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/detect/linescan.rs:134:53
+    |
+134 |                 let x_end = min(img.dimensions().0, (loc.x + 3.5 * c.module_size) as u32);
+    |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/detect/linescan.rs:135:31
+    |
+135 |                 let y_start = (loc.y - 3.5 * c.module_size).max(0.0_f64) as u32;
+    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/detect/linescan.rs:135:31
+    |
+135 |                 let y_start = (loc.y - 3.5 * c.module_size).max(0.0_f64) as u32;
+    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/detect/linescan.rs:136:53
+    |
+136 |                 let y_end = min(img.dimensions().0, (loc.y + 3.5 * c.module_size) as u32);
+    |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/detect/linescan.rs:136:53
+    |
+136 |                 let y_end = min(img.dimensions().0, (loc.y + 3.5 * c.module_size) as u32);
+    |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: redundant pattern matching, consider using `is_ok()`
+   --> src/detect/linescan.rs:152:20
+    |
+152 |             if let Ok(_) = create_dir_all(tmp.clone()) {
+    |             -------^^^^^------------------------------ help: try: `if create_dir_all(tmp.clone()).is_ok()`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching
+    = note: `#[deny(clippy::redundant_pattern_matching)]` implied by `#[deny(warnings)]`
+
+error: matching over `()` is more explicit
+   --> src/detect/linescan.rs:152:23
+    |
+152 |             if let Ok(_) = create_dir_all(tmp.clone()) {
+    |                       ^ help: use `()` instead of `_`: `()`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ignored_unit_patterns
+    = note: `#[deny(clippy::ignored_unit_patterns)]` implied by `#[deny(warnings)]`
+
+error: redundant pattern matching, consider using `is_ok()`
+   --> src/detect/linescan.rs:155:24
+    |
+155 |                 if let Ok(_) = DynamicImage::ImageRgb8(img).save(tmp.clone()) {
+    |                 -------^^^^^------------------------------------------------- help: try: `if DynamicImage::ImageRgb8(img).save(tmp.clone()).is_ok()`
+    |
+    = note: this will change drop order of the result, as well as all temporaries
+    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching
+
+error: matching over `()` is more explicit
+   --> src/detect/linescan.rs:155:27
+    |
+155 |                 if let Ok(_) = DynamicImage::ImageRgb8(img).save(tmp.clone()) {
+    |                           ^ help: use `()` instead of `_`: `()`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ignored_unit_patterns
+
+error: unnecessary `Debug` formatting in `debug!` args
+   --> src/detect/linescan.rs:156:81
+    |
+156 |                     debug!("Debug image with locator candidates saved to {:?}", tmp);
+    |                                                                                 ^^^
+    |
+    = help: use `Display` formatting and change this to `tmp.display()`
+    = note: switching to `Display` formatting will change how the value is shown; escaped characters will no longer be escaped and surrounding quotes will be removed
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_debug_formatting
+    = note: `#[deny(clippy::unnecessary_debug_formatting)]` implied by `#[deny(warnings)]`
+
+error: variables can be used directly in the `format!` string
+   --> src/detect/linescan.rs:156:21
+    |
+156 |                     debug!("Debug image with locator candidates saved to {:?}", tmp);
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+156 -                     debug!("Debug image with locator candidates saved to {:?}", tmp);
+156 +                     debug!("Debug image with locator candidates saved to {tmp:?}");
+    |
+
+error: variables can be used directly in the `format!` string
+   --> src/detect/linescan.rs:174:17
+    |
+174 |                 trace!("DIFF 1 {}", diff1);
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+174 -                 trace!("DIFF 1 {}", diff1);
+174 +                 trace!("DIFF 1 {diff1}");
+    |
+
+error: variables can be used directly in the `format!` string
+   --> src/detect/linescan.rs:186:21
+    |
+186 |                     trace!("DIFF 2 {}", diff2);
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+186 -                     trace!("DIFF 2 {}", diff2);
+186 +                     trace!("DIFF 2 {diff2}");
+    |
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/detect/linescan.rs:217:23
+    |
+217 |         let start_x = (finder.x - 5.0 * module_size).max(0.0_f64).round() as u32;
+    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/detect/linescan.rs:217:23
+    |
+217 |         let start_x = (finder.x - 5.0 * module_size).max(0.0_f64).round() as u32;
+    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/detect/linescan.rs:219:13
+    |
+219 |             (finder.x + 5.0 * module_size).round() as u32,
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/detect/linescan.rs:219:13
+    |
+219 |             (finder.x + 5.0 * module_size).round() as u32,
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/detect/linescan.rs:225:30
+    |
+225 |         let range_y = repeat(finder.y.round() as u32);
+    |                              ^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/detect/linescan.rs:225:30
+    |
+225 |         let range_y = repeat(finder.y.round() as u32);
+    |                              ^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/detect/linescan.rs:238:23
+    |
+238 |         let start_y = (finder.y - 5.0 * module_size).max(0.0_f64).round() as u32;
+    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/detect/linescan.rs:238:23
+    |
+238 |         let start_y = (finder.y - 5.0 * module_size).max(0.0_f64).round() as u32;
+    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/detect/linescan.rs:240:13
+    |
+240 |             (finder.y + 5.0 * module_size).round() as u32,
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/detect/linescan.rs:240:13
+    |
+240 |             (finder.y + 5.0 * module_size).round() as u32,
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/detect/linescan.rs:245:30
+    |
+245 |         let range_x = repeat(finder.x.round() as u32);
+    |                              ^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/detect/linescan.rs:245:30
+    |
+245 |         let range_x = repeat(finder.x.round() as u32);
+    |                              ^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/detect/linescan.rs:280:23
+    |
+280 |         let range_x = start_x.round() as u32
+    |                       ^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/detect/linescan.rs:280:23
+    |
+280 |         let range_x = start_x.round() as u32
+    |                       ^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/detect/linescan.rs:282:17
+    |
+282 |                 (finder.x + 5.0 * module_size).round() as u32,
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/detect/linescan.rs:282:17
+    |
+282 |                 (finder.x + 5.0 * module_size).round() as u32,
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/detect/linescan.rs:285:23
+    |
+285 |         let range_y = start_y.round() as u32
+    |                       ^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/detect/linescan.rs:285:23
+    |
+285 |         let range_y = start_y.round() as u32
+    |                       ^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/detect/linescan.rs:287:17
+    |
+287 |                 (finder.y + 5.0 * module_size).round() as u32,
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/detect/linescan.rs:287:17
+    |
+287 |                 (finder.y + 5.0 * module_size).round() as u32,
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: unused `self` argument
+   --> src/detect/linescan.rs:295:9
+    |
+295 |         &self,
+    |         ^^^^^
+    |
+    = help: consider refactoring to an associated function
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unused_self
+    = note: `#[deny(clippy::unused_self)]` implied by `#[deny(warnings)]`
+
+error: manual implementation of `midpoint` which can overflow
+   --> src/detect/linescan.rs:319:44
+    |
+319 |                     let new_est_mod_size = (module_size + pattern.est_mod_size()) / 2.0;
+    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `f64::midpoint` instead: `f64::midpoint(module_size, pattern.est_mod_size())`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_midpoint
+    = note: `#[deny(clippy::manual_midpoint)]` implied by `#[deny(warnings)]`
+
+error: manual implementation of `midpoint` which can overflow
+   --> src/detect/linescan.rs:344:36
+    |
+344 |             let new_est_mod_size = (module_size + pattern.est_mod_size()) / 2.0;
+    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `f64::midpoint` instead: `f64::midpoint(module_size, pattern.est_mod_size())`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_midpoint
+
+error: manual implementation of `Option::map`
+   --> src/detect/linescan.rs:456:12
+    |
+456 |       } else if let Some(qr) = find_qr_internal(three, one, two, module_size) {
+    |  ____________^
+457 | |         Some(qr)
+458 | |     } else {
+459 | |         None
+460 | |     }
+    | |_____^ help: try: `{ find_qr_internal(three, one, two, module_size).map(|qr| qr) }`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_map
+    = note: `#[deny(clippy::manual_map)]` implied by `#[deny(warnings)]`
+
+error: variables can be used directly in the `format!` string
+   --> src/detect/linescan.rs:488:5
+    |
+488 |     trace!("PERPENDICULAR {}", perpendicular);
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+488 -     trace!("PERPENDICULAR {}", perpendicular);
+488 +     trace!("PERPENDICULAR {perpendicular}");
+    |
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/detect/linescan.rs:496:20
+    |
+496 |     let mut dist = ((dist(one, three) / module_size) + 7.0) as u32;
+    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/detect/linescan.rs:496:20
+    |
+496 |     let mut dist = ((dist(one, three) / module_size) + 7.0) as u32;
+    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: variables can be used directly in the `format!` string
+   --> src/detect/linescan.rs:498:5
+    |
+498 |     trace!("DIST {}", dist);
+    |     ^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+498 -     trace!("DIST {}", dist);
+498 +     trace!("DIST {dist}");
+    |
+
+error: item in documentation is missing backticks
+  --> src/extract/qr/mod.rs:28:25
+   |
+28 |     /// Construct a new QRExtractor
+   |                         ^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+   |
+28 -     /// Construct a new QRExtractor
+28 +     /// Construct a new `QRExtractor`
+   |
+
+error: this method could have a `#[must_use]` attribute
+  --> src/extract/qr/mod.rs:29:5
+   |
+29 |     pub fn new() -> QRExtractor {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn new() -> QRExtractor`
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate
+
+error: variables can be used directly in the `format!` string
+  --> src/extract/qr/mod.rs:39:9
+   |
+39 |         debug!("PERSPECTIVE {:?}", p);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+39 -         debug!("PERSPECTIVE {:?}", p);
+39 +         debug!("PERSPECTIVE {p:?}");
+   |
+
+error: variables can be used directly in the `format!` string
+  --> src/extract/qr/mod.rs:43:9
+   |
+43 |         debug!("START {:?}", start);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+43 -         debug!("START {:?}", start);
+43 +         debug!("START {start:?}");
+   |
+
+error: casting `f64` to `u32` may truncate the value
+  --> src/extract/qr/mod.rs:56:25
+   |
+56 |                 let x = line.x.round() as u32;
+   |                         ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+  --> src/extract/qr/mod.rs:56:25
+   |
+56 |                 let x = line.x.round() as u32;
+   |                         ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+  --> src/extract/qr/mod.rs:57:25
+   |
+57 |                 let y = line.y.round() as u32;
+   |                         ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+  --> src/extract/qr/mod.rs:57:25
+   |
+57 |                 let y = line.y.round() as u32;
+   |                         ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: redundant pattern matching, consider using `is_ok()`
+  --> src/extract/qr/mod.rs:86:20
+   |
+86 |             if let Ok(_) = create_dir_all(tmp.clone()) {
+   |             -------^^^^^------------------------------ help: try: `if create_dir_all(tmp.clone()).is_ok()`
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching
+
+error: matching over `()` is more explicit
+  --> src/extract/qr/mod.rs:86:23
+   |
+86 |             if let Ok(_) = create_dir_all(tmp.clone()) {
+   |                       ^ help: use `()` instead of `_`: `()`
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ignored_unit_patterns
+
+error: redundant pattern matching, consider using `is_ok()`
+  --> src/extract/qr/mod.rs:92:24
+   |
+92 |                 if let Ok(_) = DynamicImage::ImageRgb8(img).save(tmp.clone()) {
+   |                 -------^^^^^------------------------------------------------- help: try: `if DynamicImage::ImageRgb8(img).save(tmp.clone()).is_ok()`
+   |
+   = note: this will change drop order of the result, as well as all temporaries
+   = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching
+
+error: matching over `()` is more explicit
+  --> src/extract/qr/mod.rs:92:27
+   |
+92 |                 if let Ok(_) = DynamicImage::ImageRgb8(img).save(tmp.clone()) {
+   |                           ^ help: use `()` instead of `_`: `()`
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ignored_unit_patterns
+
+error: unnecessary `Debug` formatting in `debug!` args
+  --> src/extract/qr/mod.rs:93:74
+   |
+93 |                     debug!("Debug image with data pixels saved to {:?}", tmp);
+   |                                                                          ^^^
+   |
+   = help: use `Display` formatting and change this to `tmp.display()`
+   = note: switching to `Display` formatting will change how the value is shown; escaped characters will no longer be escaped and surrounding quotes will be removed
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_debug_formatting
+
+error: variables can be used directly in the `format!` string
+  --> src/extract/qr/mod.rs:93:21
+   |
+93 |                     debug!("Debug image with data pixels saved to {:?}", tmp);
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+   |
+93 -                     debug!("Debug image with data pixels saved to {:?}", tmp);
+93 +                     debug!("Debug image with data pixels saved to {tmp:?}");
+   |
+
+error: this function has too many lines (137/100)
+   --> src/extract/qr/mod.rs:102:1
+    |
+102 | / fn determine_perspective(
+103 | |     prepared: &GrayImage,
+104 | |     version: u32,
+105 | |     size: u32,
+...   |
+276 | |     Ok(Perspective::new(dx, delta, dy, Delta { dx: 0.0, dy: 0.0 }))
+277 | | }
+    | |_^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_many_lines
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:183:16
+    |
+183 |     let al_x = est_alignment.x.round() as u32;
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:183:16
+    |
+183 |     let al_x = est_alignment.x.round() as u32;
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:184:16
+    |
+184 |     let al_y = est_alignment.y.round() as u32;
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:184:16
+    |
+184 |     let al_y = est_alignment.y.round() as u32;
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: variables can be used directly in the `format!` string
+   --> src/extract/qr/mod.rs:201:5
+    |
+201 |     debug!("LEFT X {} RIGHT X {}", left_x, right_x);
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+201 -     debug!("LEFT X {} RIGHT X {}", left_x, right_x);
+201 +     debug!("LEFT X {left_x} RIGHT X {right_x}");
+    |
+
+error: manual implementation of `midpoint` which can overflow
+   --> src/extract/qr/mod.rs:202:23
+    |
+202 |     est_alignment.x = (f64::from(left_x) + f64::from(right_x)) / 2.0;
+    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `f64::midpoint` instead: `f64::midpoint(f64::from(left_x), f64::from(right_x))`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_midpoint
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:204:16
+    |
+204 |     let al_x = est_alignment.x.round() as u32;
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:204:16
+    |
+204 |     let al_x = est_alignment.x.round() as u32;
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:205:16
+    |
+205 |     let al_y = est_alignment.y.round() as u32;
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:205:16
+    |
+205 |     let al_y = est_alignment.y.round() as u32;
+    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: variables can be used directly in the `format!` string
+   --> src/extract/qr/mod.rs:223:5
+    |
+223 |     debug!("TOP Y {} BOTTOM Y {}", top_y, bottom_y);
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+223 -     debug!("TOP Y {} BOTTOM Y {}", top_y, bottom_y);
+223 +     debug!("TOP Y {top_y} BOTTOM Y {bottom_y}");
+    |
+
+error: manual implementation of `midpoint` which can overflow
+   --> src/extract/qr/mod.rs:224:23
+    |
+224 |     est_alignment.y = (f64::from(top_y) + f64::from(bottom_y)) / 2.0;
+    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `f64::midpoint` instead: `f64::midpoint(f64::from(top_y), f64::from(bottom_y))`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_midpoint
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:230:30
+    |
+230 |         let x_start = max(0, (est_alignment.x - 2.5 * loc.module_size) as u32);
+    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:230:30
+    |
+230 |         let x_start = max(0, (est_alignment.x - 2.5 * loc.module_size) as u32);
+    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:233:13
+    |
+233 |             (est_alignment.x + 2.5 * loc.module_size) as u32,
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:233:13
+    |
+233 |             (est_alignment.x + 2.5 * loc.module_size) as u32,
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:235:30
+    |
+235 |         let y_start = max(0, (est_alignment.y - 2.5 * loc.module_size) as u32);
+    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:235:30
+    |
+235 |         let y_start = max(0, (est_alignment.y - 2.5 * loc.module_size) as u32);
+    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:238:13
+    |
+238 |             (est_alignment.y + 2.5 * loc.module_size) as u32,
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:238:13
+    |
+238 |             (est_alignment.y + 2.5 * loc.module_size) as u32,
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: redundant pattern matching, consider using `is_ok()`
+   --> src/extract/qr/mod.rs:254:16
+    |
+254 |         if let Ok(_) = create_dir_all(tmp.clone()) {
+    |         -------^^^^^------------------------------ help: try: `if create_dir_all(tmp.clone()).is_ok()`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching
+
+error: matching over `()` is more explicit
+   --> src/extract/qr/mod.rs:254:19
+    |
+254 |         if let Ok(_) = create_dir_all(tmp.clone()) {
+    |                   ^ help: use `()` instead of `_`: `()`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ignored_unit_patterns
+
+error: redundant pattern matching, consider using `is_ok()`
+   --> src/extract/qr/mod.rs:257:20
+    |
+257 |             if let Ok(_) = DynamicImage::ImageRgb8(img).save(tmp.clone()) {
+    |             -------^^^^^------------------------------------------------- help: try: `if DynamicImage::ImageRgb8(img).save(tmp.clone()).is_ok()`
+    |
+    = note: this will change drop order of the result, as well as all temporaries
+    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching
+
+error: matching over `()` is more explicit
+   --> src/extract/qr/mod.rs:257:23
+    |
+257 |             if let Ok(_) = DynamicImage::ImageRgb8(img).save(tmp.clone()) {
+    |                       ^ help: use `()` instead of `_`: `()`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ignored_unit_patterns
+
+error: unnecessary `Debug` formatting in `debug!` args
+   --> src/extract/qr/mod.rs:258:70
+    |
+258 |                 debug!("Debug image with data pixels saved to {:?}", tmp);
+    |                                                                      ^^^
+    |
+    = help: use `Display` formatting and change this to `tmp.display()`
+    = note: switching to `Display` formatting will change how the value is shown; escaped characters will no longer be escaped and surrounding quotes will be removed
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_debug_formatting
+
+error: variables can be used directly in the `format!` string
+   --> src/extract/qr/mod.rs:258:17
+    |
+258 |                 debug!("Debug image with data pixels saved to {:?}", tmp);
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+258 -                 debug!("Debug image with data pixels saved to {:?}", tmp);
+258 +                 debug!("Debug image with data pixels saved to {tmp:?}");
+    |
+
+error: variables can be used directly in the `format!` string
+   --> src/extract/qr/mod.rs:268:5
+    |
+268 |     debug!("ORIG EST {:?}, NEW EST {:?}", orig_estimate, est_alignment);
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+268 -     debug!("ORIG EST {:?}, NEW EST {:?}", orig_estimate, est_alignment);
+268 +     debug!("ORIG EST {orig_estimate:?}, NEW EST {est_alignment:?}");
+    |
+
+error: variables can be used directly in the `format!` string
+   --> src/extract/qr/mod.rs:272:5
+    |
+272 |     debug!("DELTA {:?}", delta);
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+272 -     debug!("DELTA {:?}", delta);
+272 +     debug!("DELTA {delta:?}");
+    |
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:294:11
+    |
+294 |         let x = pp.x.round() as u32;
+    |                 ^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:294:11
+    |
+294 |         let x = pp.x.round() as u32;
+    |                 ^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:295:11
+    |
+295 |         let y = pp.y.round() as u32;
+    |                 ^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:295:11
+    |
+295 |         let y = pp.y.round() as u32;
+    |                 ^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: redundant pattern matching, consider using `is_ok()`
+   --> src/extract/qr/mod.rs:306:16
+    |
+306 |         if let Ok(_) = create_dir_all(tmp.clone()) {
+    |         -------^^^^^------------------------------ help: try: `if create_dir_all(tmp.clone()).is_ok()`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching
+
+error: matching over `()` is more explicit
+   --> src/extract/qr/mod.rs:306:19
+    |
+306 |         if let Ok(_) = create_dir_all(tmp.clone()) {
+    |                   ^ help: use `()` instead of `_`: `()`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ignored_unit_patterns
+
+error: redundant pattern matching, consider using `is_ok()`
+   --> src/extract/qr/mod.rs:312:20
+    |
+312 |             if let Ok(_) = DynamicImage::ImageRgb8(img).save(tmp.clone()) {
+    |             -------^^^^^------------------------------------------------- help: try: `if DynamicImage::ImageRgb8(img).save(tmp.clone()).is_ok()`
+    |
+    = note: this will change drop order of the result, as well as all temporaries
+    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching
+
+error: matching over `()` is more explicit
+   --> src/extract/qr/mod.rs:312:23
+    |
+312 |             if let Ok(_) = DynamicImage::ImageRgb8(img).save(tmp.clone()) {
+    |                       ^ help: use `()` instead of `_`: `()`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ignored_unit_patterns
+
+error: unnecessary `Debug` formatting in `debug!` args
+   --> src/extract/qr/mod.rs:313:70
+    |
+313 |                 debug!("Debug image with data pixels saved to {:?}", tmp);
+    |                                                                      ^^^
+    |
+    = help: use `Display` formatting and change this to `tmp.display()`
+    = note: switching to `Display` formatting will change how the value is shown; escaped characters will no longer be escaped and surrounding quotes will be removed
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_debug_formatting
+
+error: variables can be used directly in the `format!` string
+   --> src/extract/qr/mod.rs:313:17
+    |
+313 |                 debug!("Debug image with data pixels saved to {:?}", tmp);
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+313 -                 debug!("Debug image with data pixels saved to {:?}", tmp);
+313 +                 debug!("Debug image with data pixels saved to {tmp:?}");
+    |
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:331:31
+    |
+331 |         if prepared.get_pixel(twice_up.x.round() as u32, twice_up.y.round() as u32)[0] == 255 {
+    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:331:31
+    |
+331 |         if prepared.get_pixel(twice_up.x.round() as u32, twice_up.y.round() as u32)[0] == 255 {
+    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:331:58
+    |
+331 |         if prepared.get_pixel(twice_up.x.round() as u32, twice_up.y.round() as u32)[0] == 255 {
+    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:331:58
+    |
+331 |         if prepared.get_pixel(twice_up.x.round() as u32, twice_up.y.round() as u32)[0] == 255 {
+    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:336:31
+    |
+336 |         if prepared.get_pixel(twice_down.x.round() as u32, twice_down.y.round() as u32)[0] == 255 {
+    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:336:31
+    |
+336 |         if prepared.get_pixel(twice_down.x.round() as u32, twice_down.y.round() as u32)[0] == 255 {
+    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:336:60
+    |
+336 |         if prepared.get_pixel(twice_down.x.round() as u32, twice_down.y.round() as u32)[0] == 255 {
+    |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:336:60
+    |
+336 |         if prepared.get_pixel(twice_down.x.round() as u32, twice_down.y.round() as u32)[0] == 255 {
+    |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:343:31
+    |
+343 |         if prepared.get_pixel(twice_left.x.round() as u32, twice_left.y.round() as u32)[0] == 255 {
+    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:343:31
+    |
+343 |         if prepared.get_pixel(twice_left.x.round() as u32, twice_left.y.round() as u32)[0] == 255 {
+    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:343:60
+    |
+343 |         if prepared.get_pixel(twice_left.x.round() as u32, twice_left.y.round() as u32)[0] == 255 {
+    |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:343:60
+    |
+343 |         if prepared.get_pixel(twice_left.x.round() as u32, twice_left.y.round() as u32)[0] == 255 {
+    |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:348:31
+    |
+348 |         if prepared.get_pixel(twice_right.x.round() as u32, twice_right.y.round() as u32)[0] == 255
+    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:348:31
+    |
+348 |         if prepared.get_pixel(twice_right.x.round() as u32, twice_right.y.round() as u32)[0] == 255
+    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:348:61
+    |
+348 |         if prepared.get_pixel(twice_right.x.round() as u32, twice_right.y.round() as u32)[0] == 255
+    |                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:348:61
+    |
+348 |         if prepared.get_pixel(twice_right.x.round() as u32, twice_right.y.round() as u32)[0] == 255
+    |                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:354:31
+    |
+354 |         if prepared.get_pixel(left.x.round() as u32, left.y.round() as u32)[0] == 0 {
+    |                               ^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:354:31
+    |
+354 |         if prepared.get_pixel(left.x.round() as u32, left.y.round() as u32)[0] == 0 {
+    |                               ^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:354:54
+    |
+354 |         if prepared.get_pixel(left.x.round() as u32, left.y.round() as u32)[0] == 0 {
+    |                                                      ^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:354:54
+    |
+354 |         if prepared.get_pixel(left.x.round() as u32, left.y.round() as u32)[0] == 0 {
+    |                                                      ^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:359:31
+    |
+359 |         if prepared.get_pixel(right.x.round() as u32, right.y.round() as u32)[0] == 0 {
+    |                               ^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:359:31
+    |
+359 |         if prepared.get_pixel(right.x.round() as u32, right.y.round() as u32)[0] == 0 {
+    |                               ^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:359:55
+    |
+359 |         if prepared.get_pixel(right.x.round() as u32, right.y.round() as u32)[0] == 0 {
+    |                                                       ^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:359:55
+    |
+359 |         if prepared.get_pixel(right.x.round() as u32, right.y.round() as u32)[0] == 0 {
+    |                                                       ^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:365:27
+    |
+365 |     if prepared.get_pixel(up.x.round() as u32, up.y.round() as u32)[0] == 0 {
+    |                           ^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:365:27
+    |
+365 |     if prepared.get_pixel(up.x.round() as u32, up.y.round() as u32)[0] == 0 {
+    |                           ^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:365:48
+    |
+365 |     if prepared.get_pixel(up.x.round() as u32, up.y.round() as u32)[0] == 0 {
+    |                                                ^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:365:48
+    |
+365 |     if prepared.get_pixel(up.x.round() as u32, up.y.round() as u32)[0] == 0 {
+    |                                                ^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:370:27
+    |
+370 |     if prepared.get_pixel(down.x.round() as u32, down.y.round() as u32)[0] == 0 {
+    |                           ^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:370:27
+    |
+370 |     if prepared.get_pixel(down.x.round() as u32, down.y.round() as u32)[0] == 0 {
+    |                           ^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:370:50
+    |
+370 |     if prepared.get_pixel(down.x.round() as u32, down.y.round() as u32)[0] == 0 {
+    |                                                  ^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:370:50
+    |
+370 |     if prepared.get_pixel(down.x.round() as u32, down.y.round() as u32)[0] == 0 {
+    |                                                  ^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:374:24
+    |
+374 |     prepared.get_pixel(p.x.round() as u32, p.y.round() as u32)[0] == 0
+    |                        ^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:374:24
+    |
+374 |     prepared.get_pixel(p.x.round() as u32, p.y.round() as u32)[0] == 0
+    |                        ^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: casting `f64` to `u32` may truncate the value
+   --> src/extract/qr/mod.rs:374:44
+    |
+374 |     prepared.get_pixel(p.x.round() as u32, p.y.round() as u32)[0] == 0
+    |                                            ^^^^^^^^^^^^^^^^^^
+    |
+    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
+
+error: casting `f64` to `u32` may lose the sign of the value
+   --> src/extract/qr/mod.rs:374:44
+    |
+374 |     prepared.get_pixel(p.x.round() as u32, p.y.round() as u32)[0] == 0
+    |                                            ^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss
+
+error: docs for function returning `Result` missing `# Errors` section
+  --> src/extract/mod.rs:49:5
+   |
+49 |     fn extract(&self, prepared: &PREPD, loc: LOC) -> Result<DATA, ERROR>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc
+
+error: item in documentation is missing backticks
+  --> src/prepare/blockedmean.rs:20:25
+   |
+20 |     /// Construct a new BlockedMean
+   |                         ^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+   |
+20 -     /// Construct a new BlockedMean
+20 +     /// Construct a new `BlockedMean`
+   |
+
+error: this method could have a `#[must_use]` attribute
+  --> src/prepare/blockedmean.rs:26:5
+   |
+26 |     pub fn new(block_size: u32, block_mean_size: u32) -> BlockedMean {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn new(block_size: u32, block_mean_size: u32) -> BlockedMean`
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate
+
+error: casting `u64` to `f64` causes a loss of precision (`u64` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
+  --> src/prepare/blockedmean.rs:76:25
+   |
+76 |             stat.mean = stat.total as f64 / stat.count as f64;
+   |                         ^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_precision_loss
+   = note: `#[deny(clippy::cast_precision_loss)]` implied by `#[deny(warnings)]`
+
+error: casting `u64` to `f64` causes a loss of precision (`u64` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
+  --> src/prepare/blockedmean.rs:76:45
+   |
+76 |             stat.mean = stat.total as f64 / stat.count as f64;
+   |                                             ^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_precision_loss
+
+error: casting `u64` to `f64` causes a loss of precision (`u64` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
+   --> src/prepare/blockedmean.rs:123:21
+    |
+123 |                     total as f64 / count as f64;
+    |                     ^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_precision_loss
+
+error: casting `u64` to `f64` causes a loss of precision (`u64` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
+   --> src/prepare/blockedmean.rs:123:36
+    |
+123 |                     total as f64 / count as f64;
+    |                                    ^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_precision_loss
+
+error: this method could have a `#[must_use]` attribute
+  --> src/util/chomp.rs:35:5
+   |
+35 |     pub fn new(bytes: Vec<u8>) -> Chomp {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn new(bytes: Vec<u8>) -> Chomp`
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate
+
+error: docs for function returning `Result` missing `# Errors` section
+  --> src/util/chomp.rs:55:5
+   |
+55 |     pub fn chomp_or<E>(&mut self, nr_bits: u8, err: E) -> Result<u8, E> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc
+
+error: docs for function returning `Result` missing `# Errors` section
+  --> src/util/chomp.rs:61:5
+   |
+61 |     pub fn chomp_or_u16<E: Clone>(&mut self, nr_bits: u8, err: E) -> Result<u16, E> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc
+
+error: docs for function which may panic missing `# Panics` section
+   --> src/util/chomp.rs:77:5
+    |
+77  |     pub fn chomp(&mut self, nr_bits: u8) -> Option<u8> {
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+note: first possible panic found here
+   --> src/util/chomp.rs:116:26
+    |
+116 |               let nibble = self.nibble(bits_to_go)
+    |  __________________________^
+117 | |                 .expect("nibble() should succeed after successful peek()"); // we just peeked
+    | |__________________________________________________________________________^
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#missing_panics_doc
+    = note: `#[deny(clippy::missing_panics_doc)]` implied by `#[deny(warnings)]`
+
+error: manual `!RangeInclusive::contains` implementation
+  --> src/util/chomp.rs:79:12
+   |
+79 |         if nr_bits < 1 || nr_bits > 8 || bit_count > self.bits_left {
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!(1..=8).contains(&nr_bits)`
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains
+   = note: `#[deny(clippy::manual_range_contains)]` implied by `#[deny(warnings)]`
+
+error: item in documentation is missing backticks
+  --> src/util/qr.rs:59:22
+   |
+59 |     /// Create a new QRData object with the provided data and version. `side` will be calculated automatically.
+   |                      ^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+help: try
+   |
+59 -     /// Create a new QRData object with the provided data and version. `side` will be calculated automatically.
+59 +     /// Create a new `QRData` object with the provided data and version. `side` will be calculated automatically.
+   |
+
+error: this method could have a `#[must_use]` attribute
+  --> src/util/qr.rs:60:5
+   |
+60 |     pub fn new(data: Vec<u8>, version: u32) -> QRData {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn new(data: Vec<u8>, version: u32) -> QRData`
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate
+
+error: non-local `impl` definition, `impl` blocks should be written at the same level as their item
+  --> src/decoder.rs:15:17
+   |
+15 | #[derive(Debug, Fail)]
+   |                 ^---
+   |                 |
+   |                 `Fail` is not local
+   |                 move the `impl` block outside of this constant `_DERIVE_failure_Fail_FOR_BuilderError`
+16 | pub enum BuilderError {
+   |          ------------ `BuilderError` is not local
+   |
+   = note: the derive macro `Fail` defines the non-local `impl`, and may need to be changed
+   = note: the derive macro `Fail` may come from an old version of the `failure_derive` crate, try updating your dependency with `cargo update -p failure_derive`
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+   = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration for the purpose of this lint
+   = note: `#[deny(non_local_definitions)]` implied by `#[deny(warnings)]`
+   = note: this error originates in the derive macro `Fail` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: non-local `impl` definition, `impl` blocks should be written at the same level as their item
+  --> src/decoder.rs:15:17
+   |
+15 | #[derive(Debug, Fail)]
+   |                 ^---
+   |                 |
+   |                 `Display` is not local
+   |                 move the `impl` block outside of this constant `_DERIVE_failure_core_fmt_Display_FOR_BuilderError`
+16 | pub enum BuilderError {
+   |          ------------ `BuilderError` is not local
+   |
+   = note: the derive macro `Fail` defines the non-local `impl`, and may need to be changed
+   = note: the derive macro `Fail` may come from an old version of the `failure_derive` crate, try updating your dependency with `cargo update -p failure_derive`
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+   = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration for the purpose of this lint
+   = note: this error originates in the derive macro `Fail` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: non-local `impl` definition, `impl` blocks should be written at the same level as their item
+  --> src/util/qr.rs:10:10
+   |
+10 | #[derive(Fail, Debug, Clone, PartialEq)]
+   |          ^---
+   |          |
+   |          `Fail` is not local
+   |          move the `impl` block outside of this constant `_DERIVE_failure_Fail_FOR_QRError`
+11 | #[fail(display = "Error decoding QR Code: {}", msg)]
+12 | pub struct QRError {
+   |            ------- `QRError` is not local
+   |
+   = note: the derive macro `Fail` defines the non-local `impl`, and may need to be changed
+   = note: the derive macro `Fail` may come from an old version of the `failure_derive` crate, try updating your dependency with `cargo update -p failure_derive`
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+   = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration for the purpose of this lint
+   = note: this error originates in the derive macro `Fail` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: non-local `impl` definition, `impl` blocks should be written at the same level as their item
+  --> src/util/qr.rs:10:10
+   |
+10 | #[derive(Fail, Debug, Clone, PartialEq)]
+   |          ^---
+   |          |
+   |          `Display` is not local
+   |          move the `impl` block outside of this constant `_DERIVE_failure_core_fmt_Display_FOR_QRError`
+11 | #[fail(display = "Error decoding QR Code: {}", msg)]
+12 | pub struct QRError {
+   |            ------- `QRError` is not local
+   |
+   = note: the derive macro `Fail` defines the non-local `impl`, and may need to be changed
+   = note: the derive macro `Fail` may come from an old version of the `failure_derive` crate, try updating your dependency with `cargo update -p failure_derive`
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+   = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration for the purpose of this lint
+   = note: this error originates in the derive macro `Fail` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: manual `RangeInclusive::contains` implementation
+   --> src/decode/qr/blocks.rs:285:16
+    |
+285 |             if (x >= 4 && x <= 8)
+    |                ^^^^^^^^^^^^^^^^^^ help: use: `(4..=8).contains(&x)`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains
+    = note: `#[deny(clippy::manual_range_contains)]` implied by `#[deny(warnings)]`
+
+error: manual `RangeInclusive::contains` implementation
+   --> src/decode/qr/blocks.rs:286:20
+    |
+286 |                 || (x >= 22 && x <= 26)
+    |                    ^^^^^^^^^^^^^^^^^^^^ help: use: `(22..=26).contains(&x)`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains
+
+error: manual `RangeInclusive::contains` implementation
+   --> src/decode/qr/blocks.rs:287:20
+    |
+287 |                 || (x >= 48 && x <= 52)
+    |                    ^^^^^^^^^^^^^^^^^^^^ help: use: `(48..=52).contains(&x)`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains
+
+error: manual `RangeInclusive::contains` implementation
+   --> src/decode/qr/blocks.rs:288:20
+    |
+288 |                 || (x >= 74 && x <= 78)
+    |                    ^^^^^^^^^^^^^^^^^^^^ help: use: `(74..=78).contains(&x)`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains
+
+error: manual `RangeInclusive::contains` implementation
+   --> src/decode/qr/blocks.rs:289:20
+    |
+289 |                 || (x >= 100 && x <= 104)
+    |                    ^^^^^^^^^^^^^^^^^^^^^^ help: use: `(100..=104).contains(&x)`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains
+
+error: manual `RangeInclusive::contains` implementation
+   --> src/decode/qr/blocks.rs:290:20
+    |
+290 |                 || (x >= 126 && x <= 130)
+    |                    ^^^^^^^^^^^^^^^^^^^^^^ help: use: `(126..=130).contains(&x)`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains
+
+error: manual `RangeInclusive::contains` implementation
+   --> src/decode/qr/blocks.rs:291:20
+    |
+291 |                 || (x >= 152 && x <= 156)
+    |                    ^^^^^^^^^^^^^^^^^^^^^^ help: use: `(152..=156).contains(&x)`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains
+
+error: could not compile `bardecoder` (lib) due to 237 previous errors
+warning: build failed, waiting for other jobs to finish...
+error: variables can be used directly in the `format!` string
+   --> src/decode/qr/format.rs:206:9
+    |
+206 |         println!("{:?}", output);
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
+help: change this to
+    |
+206 -         println!("{:?}", output);
+206 +         println!("{output:?}");
+    |
+
+error: items after a test module
+   --> src/decode/qr/galois.rs:112:1
+    |
+112 | mod test {
+    | ^^^^^^^^
+...
+266 | pub const EXP8: [GF8; 256] = [
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+525 | pub const LOG8: [u8; 256] = [
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+544 | pub const EXP4: [GF4; 16] = [
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+563 | pub const LOG4: [u8; 16] = [
+    | ^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#items_after_test_module
+    = note: `#[deny(clippy::items_after_test_module)]` implied by `#[deny(warnings)]`
+    = help: move the items to before the test module was defined
+
+error: manual `!RangeInclusive::contains` implementation
+  --> src/util/chomp.rs:79:12
+   |
+79 |         if nr_bits < 1 || nr_bits > 8 || bit_count > self.bits_left {
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `!(1..=8).contains(&nr_bits)`
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains
+
+error: could not compile `bardecoder` (lib test) due to 246 previous errors

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -37,7 +37,6 @@ pub use self::qr::decoder::{QRDecoder, QRDecoderWithInfo};
 /// [`Extract`]: ../extract/trait.Extract.html
 /// [`here`]: ../extract/trait.Extract.html
 /// [`Decoder`]: ../struct.Decoder.html
-
 pub trait Decode<DATA, RESULT, ERROR>
 where
     ERROR: Fail,

--- a/src/decode/qr/blocks.rs
+++ b/src/decode/qr/blocks.rs
@@ -30,7 +30,7 @@ pub fn blocks(data: &QRData, level: &ECLevel, mask: &Box<QRMask>) -> Result<Vec<
         x -= 2;
         if x == 6 {
             // skip timing pattern
-            x = 5
+            x = 5;
         }
     }
 
@@ -39,22 +39,22 @@ pub fn blocks(data: &QRData, level: &ECLevel, mask: &Box<QRMask>) -> Result<Vec<
 
     if blocks.len() != bi.len() {
         return Err(QRError {
-            msg: format!("Expected {} blocks but found {}", bi.len(), blocks.len()),
+            msg: format!("Expected {expected} blocks but found {found}", expected = bi.len(), found = blocks.len()),
         });
     }
 
     for (i, block) in blocks.iter().enumerate() {
-        debug!("BLOCK {}, CODEWORDS {}", i, block.len());
+        debug!("BLOCK {i}, CODEWORDS {len}", len = block.len());
     }
 
     for i in 0..blocks.len() {
         if bi[i].total_per as usize != blocks[i].len() {
             return Err(QRError {
                 msg: format!(
-                    "Expected {} codewords in block {} but found {}",
-                    bi[i].total_per,
-                    i,
-                    blocks[i].len()
+                    "Expected {expected} codewords in block {block} but found {found}",
+                    expected = bi[i].total_per,
+                    block = i,
+                    found = blocks[i].len()
                 ),
             });
         }
@@ -119,7 +119,7 @@ fn is_data(data: &QRData, loc: &AlignmentLocation, x: u32, y: u32) -> bool {
 }
 
 fn is_alignment_coord(loc: &AlignmentLocation, coord: u32) -> bool {
-    if coord >= 4 && coord - 4 % 6 <= 4 {
+    if coord >= 4 && coord - 4 <= 4 {
         return true;
     }
 
@@ -149,23 +149,18 @@ fn alignment_location(version: u32) -> Result<AlignmentLocation, QRError> {
         // multiple alignment patterns
         7 => Ok(AlignmentLocation::new(22, 16)),
         8 => Ok(AlignmentLocation::new(24, 18)),
-        9 => Ok(AlignmentLocation::new(26, 20)),
+        9 | 14 => Ok(AlignmentLocation::new(26, 20)),
         10 => Ok(AlignmentLocation::new(28, 22)),
-        11 => Ok(AlignmentLocation::new(30, 24)),
-        12 => Ok(AlignmentLocation::new(32, 26)),
-        13 => Ok(AlignmentLocation::new(34, 28)),
-        14 => Ok(AlignmentLocation::new(26, 20)),
+        11 | 17 => Ok(AlignmentLocation::new(30, 24)),
+        12 | 25 => Ok(AlignmentLocation::new(32, 26)),
+        13 | 20 => Ok(AlignmentLocation::new(34, 28)),
         15 => Ok(AlignmentLocation::new(26, 22)),
         16 => Ok(AlignmentLocation::new(26, 24)),
-        17 => Ok(AlignmentLocation::new(30, 24)),
         18 => Ok(AlignmentLocation::new(30, 26)),
-        19 => Ok(AlignmentLocation::new(30, 28)),
-        20 => Ok(AlignmentLocation::new(34, 28)),
-        25 => Ok(AlignmentLocation::new(32, 26)),
+        19 | 40 => Ok(AlignmentLocation::new(30, 28)),
         36 => Ok(AlignmentLocation::new(24, 26)),
-        40 => Ok(AlignmentLocation::new(30, 28)),
         _ => Err(QRError {
-            msg: format!("Unknown version {}", version),
+            msg: format!("Unknown version {version}"),
         }),
     }
 }
@@ -282,13 +277,13 @@ mod test {
         let side = 4 * 36 + 17;
 
         for x in 0..side {
-            if (x >= 4 && x <= 8)
-                || (x >= 22 && x <= 26)
-                || (x >= 48 && x <= 52)
-                || (x >= 74 && x <= 78)
-                || (x >= 100 && x <= 104)
-                || (x >= 126 && x <= 130)
-                || (x >= 152 && x <= 156)
+            if (4..=8).contains(&x)
+                || (22..=26).contains(&x)
+                || (48..=52).contains(&x)
+                || (74..=78).contains(&x)
+                || (100..=104).contains(&x)
+                || (126..=130).contains(&x)
+                || (152..=156).contains(&x)
             {
                 assert!(is_alignment_coord(&al, x));
             } else {

--- a/src/decode/qr/correct.rs
+++ b/src/decode/qr/correct.rs
@@ -32,10 +32,10 @@ pub fn correct_with_error_count(
 
     for i in 0..locs.len() {
         debug!(
-            "FIXING LOCATION {} FROM {:08b} TO {:08b}",
-            block_info.total_per as usize - 1 - locs[i] as usize,
-            block[block_info.total_per as usize - 1 - locs[i] as usize],
-            block[block_info.total_per as usize - 1 - locs[i] as usize] ^ distance[i].0
+            "FIXING LOCATION {loc} FROM {from:08b} TO {to:08b}",
+            loc = block_info.total_per as usize - 1 - locs[i] as usize,
+            from = block[block_info.total_per as usize - 1 - locs[i] as usize],
+            to = block[block_info.total_per as usize - 1 - locs[i] as usize] ^ distance[i].0
         );
 
         error_count += distance[i].0.count_ones();
@@ -56,7 +56,7 @@ fn calculate_syndromes(block: &[u8], block_info: &BlockInfo) -> (bool, Vec<GF8>)
 
     let mut all_fine = true;
     for i in 0..block_info.ec_cap * 2 {
-        syndromes[i as usize] = syndrome(&block, EXP8[i as usize]);
+        syndromes[i as usize] = syndrome(block, EXP8[i as usize]);
         if syndromes[i as usize] != GF8(0) {
             all_fine = false;
         }
@@ -103,12 +103,12 @@ fn find_locs(block_info: &BlockInfo, syndromes: &[GF8]) -> Result<Vec<usize>, QR
         check_value = check_value + x;
 
         if check_value == GF8(0) {
-            debug!("LOC {:?} {} ", exp, i);
+            debug!("LOC {exp:?} {i} ");
             locs.push(i);
         }
     }
 
-    debug!("LOCS {:?}", locs);
+    debug!("LOCS {locs:?}");
 
     Ok(locs)
 }
@@ -117,7 +117,7 @@ fn calculate_distances(syndromes: &[GF8], locs: &[usize]) -> Option<Vec<GF8>> {
     let mut eq = vec![vec![GF8(0); locs.len() + 1]; locs.len()];
     for i in 0..locs.len() {
         for j in 0..locs.len() {
-            eq[i][j] = EXP8[(i * locs[j] as usize) % 255];
+            eq[i][j] = EXP8[(i * locs[j]) % 255];
         }
 
         eq[i][locs.len()] = syndromes[i];
@@ -130,7 +130,7 @@ fn solve<T>(mut eq: Vec<Vec<T>>, zero: T, one: T, fail_on_rank: bool) -> Option<
 where
     T: Div<Output = T> + Mul<Output = T> + Sub<Output = T> + Copy + PartialEq,
 {
-    let num_eq = eq.len() as usize;
+    let num_eq = eq.len();
     if num_eq == 0 {
         return None;
     }

--- a/src/decode/qr/data.rs
+++ b/src/decode/qr/data.rs
@@ -13,7 +13,7 @@ pub fn data(input: Vec<u8>, version: u32) -> Result<String, QRError> {
             0b0000 => break,
             _ => {
                 return Err(QRError {
-                    msg: format!("Mode {:04b} not yet implemented.", mode),
+                    msg: format!("Mode {mode:04b} not yet implemented."),
                 })
             }
         }
@@ -29,7 +29,7 @@ fn numeric(chomp: &mut Chomp, version: u32) -> Result<String, QRError> {
         27..=40 => 14,
         _ => {
             return Err(QRError {
-                msg: format!("Unknown version {}", version),
+                msg: format!("Unknown version {version}"),
             });
         }
     };
@@ -37,7 +37,7 @@ fn numeric(chomp: &mut Chomp, version: u32) -> Result<String, QRError> {
     let mut length = chomp.chomp_or_u16(
         length_bits,
         QRError {
-            msg: format!("Could not read {} bits for numeric length", length_bits),
+            msg: format!("Could not read {length_bits} bits for numeric length"),
         },
     )?;
 
@@ -46,7 +46,7 @@ fn numeric(chomp: &mut Chomp, version: u32) -> Result<String, QRError> {
     while length > 0 {
         if length >= 3 {
             let digits = read_bits_u16(chomp, 10)?;
-            result.push_str(&format!("{:03}", digits));
+            result.push_str(&format!("{digits:03}"));
 
             length -= 3;
             continue;
@@ -54,20 +54,20 @@ fn numeric(chomp: &mut Chomp, version: u32) -> Result<String, QRError> {
 
         if length == 2 {
             let digits = read_bits_u16(chomp, 7)?;
-            result.push_str(&format!("{:02}", digits));
+            result.push_str(&format!("{digits:02}"));
 
             break;
         }
 
         if length == 1 {
             let digits = read_bits_u16(chomp, 4)?;
-            result.push_str(&format!("{:01}", digits));
+            result.push_str(&format!("{digits:01}"));
 
             break;
         }
     }
 
-    debug!("NUMERIC {:?}", result);
+    debug!("NUMERIC {result:?}");
 
     Ok(result)
 }
@@ -85,7 +85,7 @@ fn alphanumeric(chomp: &mut Chomp, version: u32) -> Result<String, QRError> {
         27..=40 => 13,
         _ => {
             return Err(QRError {
-                msg: format!("Unknown version {}", version),
+                msg: format!("Unknown version {version}"),
             });
         }
     };
@@ -94,8 +94,7 @@ fn alphanumeric(chomp: &mut Chomp, version: u32) -> Result<String, QRError> {
         length_bits,
         QRError {
             msg: format!(
-                "Could not read {} bits for alphanumeric length",
-                length_bits
+                "Could not read {length_bits} bits for alphanumeric length"
             ),
         },
     )?;
@@ -120,7 +119,7 @@ fn alphanumeric(chomp: &mut Chomp, version: u32) -> Result<String, QRError> {
         }
     }
 
-    debug!("ALPHANUMERIC {:?}", result);
+    debug!("ALPHANUMERIC {result:?}");
 
     Ok(result)
 }
@@ -132,7 +131,7 @@ fn eight_bit(chomp: &mut Chomp, version: u32) -> Result<String, QRError> {
         27..=40 => 16,
         _ => {
             return Err(QRError {
-                msg: format!("Unknown version {}", version),
+                msg: format!("Unknown version {version}"),
             });
         }
     };
@@ -141,8 +140,7 @@ fn eight_bit(chomp: &mut Chomp, version: u32) -> Result<String, QRError> {
         length_bits,
         QRError {
             msg: format!(
-                "Could not read {} bits for alphanumeric length",
-                length_bits
+                "Could not read {length_bits} bits for alphanumeric length"
             ),
         },
     )?;
@@ -153,7 +151,7 @@ fn eight_bit(chomp: &mut Chomp, version: u32) -> Result<String, QRError> {
         result.push(read_bits(chomp, 8)?);
     }
 
-    debug!("EIGHT BIT RAW {:?}", result);
+    debug!("EIGHT BIT RAW {result:?}");
 
     let mut may_be_utf8 = false;
 
@@ -166,14 +164,14 @@ fn eight_bit(chomp: &mut Chomp, version: u32) -> Result<String, QRError> {
 
     let final_result = if may_be_utf8 {
         let utf8 = String::from_utf8(result)?;
-        debug!("EIGHT BIT AS UTF-8 {:?}", utf8);
+        debug!("EIGHT BIT AS UTF-8 {utf8:?}");
         utf8
     } else {
         let mut iso88591 = String::new();
         for r in result {
             iso88591.push(r as char);
         }
-        debug!("EIGHT BIT AS ISO 8859-1 {:?}", iso88591);
+        debug!("EIGHT BIT AS ISO 8859-1 {iso88591:?}");
         iso88591
     };
 
@@ -184,7 +182,7 @@ fn read_bits(chomp: &mut Chomp, bits: u8) -> Result<u8, QRError> {
     chomp.chomp_or(
         bits,
         QRError {
-            msg: format!("Could not read {} bits", bits),
+            msg: format!("Could not read {bits} bits"),
         },
     )
 }
@@ -193,7 +191,7 @@ fn read_bits_u16(chomp: &mut Chomp, bits: u8) -> Result<u16, QRError> {
     chomp.chomp_or_u16(
         bits,
         QRError {
-            msg: format!("Could not read {} bits", bits),
+            msg: format!("Could not read {bits} bits"),
         },
     )
 }

--- a/src/decode/qr/decoder.rs
+++ b/src/decode/qr/decoder.rs
@@ -41,7 +41,7 @@ impl Decode<QRData, String, QRError> for QRDecoder {
             }
         }
 
-        debug!("TOTAL LENGTH {}", all_blocks.len());
+        debug!("TOTAL LENGTH {len}", len = all_blocks.len());
 
         let data = super::data::data(all_blocks, qr_data.version)?;
         Ok(data)
@@ -81,7 +81,7 @@ impl Decode<QRData, (String, QRInfo), QRError> for QRDecoderWithInfo {
             total_errors += error_count;
         }
 
-        debug!("TOTAL LENGTH {}", all_blocks.len());
+        debug!("TOTAL LENGTH {len}", len = all_blocks.len());
         let total_data = (all_blocks.len() as u32) * 8;
 
         let data = super::data::data(all_blocks, qr_data.version)?;

--- a/src/decode/qr/format.rs
+++ b/src/decode/qr/format.rs
@@ -16,11 +16,11 @@ pub fn format(data: &QRData) -> Result<(ECLevel, Box<QRMask>), QRError> {
 
     let correction = error_correction(2 * format[0] + format[1])
         .ok_or_else(|| QRError {
-            msg: format!("Invalid error correction level: {:02b}", 2 * format[0] + format[1]),
+            msg: format!("Invalid error correction level: {level:02b}", level = 2 * format[0] + format[1]),
         })?;
     let mask = mask(4 * format[2] + 2 * format[3] + format[4])
         .ok_or_else(|| QRError {
-            msg: format!("Invalid mask pattern: {:03b}", 4 * format[2] + 2 * format[3] + format[4]),
+            msg: format!("Invalid mask pattern: {pattern:03b}", pattern = 4 * format[2] + 2 * format[3] + format[4]),
         })?;
 
     Ok((correction, mask))
@@ -141,7 +141,7 @@ fn error_correction(bytes: u8) -> Option<ECLevel> {
 }
 
 fn mask(bytes: u8) -> Option<Box<QRMask>> {
-    debug!("MASK {:03b}", bytes);
+    debug!("MASK {bytes:03b}");
     match bytes {
         0b000 => qrmask(Box::new(|j, i| (i + j) % 2 == 0)),
         0b001 => qrmask(Box::new(|_, i| i % 2 == 0)),

--- a/src/decode/qr/galois.rs
+++ b/src/decode/qr/galois.rs
@@ -108,142 +108,6 @@ impl Div<GF4> for GF4 {
     }
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    pub fn test_gf8_add() {
-        // zero
-        assert_eq!(GF8(0) + GF8(123), GF8(123));
-
-        // inverse sub
-        assert_eq!(GF8(40) + GF8(193), GF8(233));
-
-        // commutativity
-        assert_eq!(GF8(40) + GF8(193), GF8(193) + GF8(40));
-
-        // associativity
-        assert_eq!(
-            (GF8(40) + GF8(193)) + GF8(78),
-            GF8(40) + (GF8(193) + GF8(78))
-        );
-    }
-
-    #[test]
-    pub fn test_gf8_sub() {
-        // zero
-        assert_eq!(GF8(123) - GF8(123), GF8(0));
-
-        // inverse add
-        assert_eq!(GF8(233) - GF8(193), GF8(40));
-        assert_eq!(GF8(233) - GF8(40), GF8(193));
-    }
-
-    #[test]
-    pub fn test_gf8_mul() {
-        // zero
-        assert_eq!(GF8(40) * GF8(0), GF8(0));
-        assert_eq!(GF8(0) * GF8(40), GF8(0));
-
-        // unit
-        assert_eq!(GF8(40) * GF8(1), GF8(40));
-        assert_eq!(GF8(1) * GF8(40), GF8(40));
-
-        // inverse div
-        assert_eq!(GF8(40) * GF8(193), GF8(67));
-
-        // commutativity
-        assert_eq!(GF8(40) * GF8(193), GF8(193) * GF8(40));
-
-        // associativity
-        assert_eq!(
-            (GF8(40) * GF8(193)) * GF8(78),
-            GF8(40) * (GF8(193) * GF8(78))
-        );
-
-        // distributivity
-        assert_eq!(
-            GF8(40) * (GF8(193) + GF8(78)),
-            GF8(40) * GF8(193) + GF8(40) * GF8(78)
-        );
-    }
-
-    #[test]
-    pub fn test_gf8_div() {
-        // unit
-        assert_eq!(GF8(40) / GF8(40), GF8(1));
-        assert_eq!(GF8(40) / GF8(1), GF8(40));
-
-        // inverse mul
-        assert_eq!(GF8(67) / GF8(193), GF8(40));
-        assert_eq!(GF8(67) / GF8(40), GF8(193));
-    }
-
-    #[test]
-    pub fn test_gf4_add() {
-        // zero
-        assert_eq!(GF4(0) + GF4(5), GF4(5));
-
-        // inverse sub
-        assert_eq!(GF4(3) + GF4(7), GF4(4));
-
-        // commutativity
-        assert_eq!(GF4(5) + GF4(9), GF4(9) + GF4(5));
-
-        // associativity
-        assert_eq!((GF4(3) + GF4(9)) + GF4(10), GF4(3) + (GF4(9) + GF4(10)));
-    }
-
-    #[test]
-    pub fn test_gf4_sub() {
-        // zero
-        assert_eq!(GF4(5) - GF4(5), GF4(0));
-
-        // inverse add
-        assert_eq!(GF4(4) - GF4(3), GF4(7));
-        assert_eq!(GF4(4) - GF4(7), GF4(3));
-    }
-
-    #[test]
-    pub fn test_gf4_mul() {
-        // zero
-        assert_eq!(GF4(4) * GF4(0), GF4(0));
-        assert_eq!(GF4(0) * GF4(4), GF4(0));
-
-        // unit
-        assert_eq!(GF4(4) * GF4(1), GF4(4));
-        assert_eq!(GF4(1) * GF4(4), GF4(4));
-
-        // inverse div
-        assert_eq!(GF4(7) * GF4(3), GF4(9));
-
-        // commutativity
-        assert_eq!(GF4(2) * GF4(9), GF4(9) * GF4(2));
-
-        // associativity
-        assert_eq!((GF4(2) * GF4(9)) * GF4(13), GF4(2) * (GF4(9) * GF4(13)));
-
-        // distributivity
-        assert_eq!(
-            GF4(2) * (GF4(5) + GF4(11)),
-            GF4(2) * GF4(5) + GF4(2) * GF4(11)
-        );
-    }
-
-    #[test]
-    pub fn test_gf4_div() {
-        // unit
-        assert_eq!(GF4(4) / GF4(4), GF4(1));
-        assert_eq!(GF4(4) / GF4(1), GF4(4));
-
-        // inverse mul
-        assert_eq!(GF4(9) / GF4(7), GF4(3));
-        assert_eq!(GF4(9) / GF4(3), GF4(7));
-    }
-
-}
-
 // exp and log tables with base 2 in Galois Field 2^8 under modulo 0b100011101
 // to generate:
 /*
@@ -563,3 +427,139 @@ pub const EXP4: [GF4; 16] = [
 pub const LOG4: [u8; 16] = [
     0x00, 0x00, 0x01, 0x04, 0x02, 0x08, 0x05, 0x0A, 0x03, 0x0E, 0x09, 0x07, 0x06, 0x0D, 0x0B, 0x0C,
 ];
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    pub fn test_gf8_add() {
+        // zero
+        assert_eq!(GF8(0) + GF8(123), GF8(123));
+
+        // inverse sub
+        assert_eq!(GF8(40) + GF8(193), GF8(233));
+
+        // commutativity
+        assert_eq!(GF8(40) + GF8(193), GF8(193) + GF8(40));
+
+        // associativity
+        assert_eq!(
+            (GF8(40) + GF8(193)) + GF8(78),
+            GF8(40) + (GF8(193) + GF8(78))
+        );
+    }
+
+    #[test]
+    pub fn test_gf8_sub() {
+        // zero
+        assert_eq!(GF8(123) - GF8(123), GF8(0));
+
+        // inverse add
+        assert_eq!(GF8(233) - GF8(193), GF8(40));
+        assert_eq!(GF8(233) - GF8(40), GF8(193));
+    }
+
+    #[test]
+    pub fn test_gf8_mul() {
+        // zero
+        assert_eq!(GF8(40) * GF8(0), GF8(0));
+        assert_eq!(GF8(0) * GF8(40), GF8(0));
+
+        // unit
+        assert_eq!(GF8(40) * GF8(1), GF8(40));
+        assert_eq!(GF8(1) * GF8(40), GF8(40));
+
+        // inverse div
+        assert_eq!(GF8(40) * GF8(193), GF8(67));
+
+        // commutativity
+        assert_eq!(GF8(40) * GF8(193), GF8(193) * GF8(40));
+
+        // associativity
+        assert_eq!(
+            (GF8(40) * GF8(193)) * GF8(78),
+            GF8(40) * (GF8(193) * GF8(78))
+        );
+
+        // distributivity
+        assert_eq!(
+            GF8(40) * (GF8(193) + GF8(78)),
+            GF8(40) * GF8(193) + GF8(40) * GF8(78)
+        );
+    }
+
+    #[test]
+    pub fn test_gf8_div() {
+        // unit
+        assert_eq!(GF8(40) / GF8(40), GF8(1));
+        assert_eq!(GF8(40) / GF8(1), GF8(40));
+
+        // inverse mul
+        assert_eq!(GF8(67) / GF8(193), GF8(40));
+        assert_eq!(GF8(67) / GF8(40), GF8(193));
+    }
+
+    #[test]
+    pub fn test_gf4_add() {
+        // zero
+        assert_eq!(GF4(0) + GF4(5), GF4(5));
+
+        // inverse sub
+        assert_eq!(GF4(3) + GF4(7), GF4(4));
+
+        // commutativity
+        assert_eq!(GF4(5) + GF4(9), GF4(9) + GF4(5));
+
+        // associativity
+        assert_eq!((GF4(3) + GF4(9)) + GF4(10), GF4(3) + (GF4(9) + GF4(10)));
+    }
+
+    #[test]
+    pub fn test_gf4_sub() {
+        // zero
+        assert_eq!(GF4(5) - GF4(5), GF4(0));
+
+        // inverse add
+        assert_eq!(GF4(4) - GF4(3), GF4(7));
+        assert_eq!(GF4(4) - GF4(7), GF4(3));
+    }
+
+    #[test]
+    pub fn test_gf4_mul() {
+        // zero
+        assert_eq!(GF4(4) * GF4(0), GF4(0));
+        assert_eq!(GF4(0) * GF4(4), GF4(0));
+
+        // unit
+        assert_eq!(GF4(4) * GF4(1), GF4(4));
+        assert_eq!(GF4(1) * GF4(4), GF4(4));
+
+        // inverse div
+        assert_eq!(GF4(7) * GF4(3), GF4(9));
+
+        // commutativity
+        assert_eq!(GF4(2) * GF4(9), GF4(9) * GF4(2));
+
+        // associativity
+        assert_eq!((GF4(2) * GF4(9)) * GF4(13), GF4(2) * (GF4(9) * GF4(13)));
+
+        // distributivity
+        assert_eq!(
+            GF4(2) * (GF4(5) + GF4(11)),
+            GF4(2) * GF4(5) + GF4(2) * GF4(11)
+        );
+    }
+
+    #[test]
+    pub fn test_gf4_div() {
+        // unit
+        assert_eq!(GF4(4) / GF4(4), GF4(1));
+        assert_eq!(GF4(4) / GF4(1), GF4(4));
+
+        // inverse mul
+        assert_eq!(GF4(9) / GF4(7), GF4(3));
+        assert_eq!(GF4(9) / GF4(3), GF4(7));
+    }
+
+}

--- a/src/decode/qr/mod.rs
+++ b/src/decode/qr/mod.rs
@@ -656,8 +656,7 @@ pub fn block_info(version: u32, level: &ECLevel) -> Result<Vec<BlockInfo>, QRErr
 
         (version, level) => Err(QRError {
             msg: format!(
-                "Unknown combination of version {} and level {:?}",
-                version, level
+                "Unknown combination of version {version} and level {level:?}"
             ),
         }),
     }?;

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -11,7 +11,7 @@ use crate::prepare::{BlockedMean, Prepare};
 
 use crate::util::qr::{QRData, QRError, QRInfo, QRLocation};
 
-/// Error type for DecoderBuilder
+/// Error type for `DecoderBuilder`
 #[derive(Debug, Fail)]
 pub enum BuilderError {
     /// The prepare component is required but was not provided
@@ -68,10 +68,10 @@ impl<IMG, PREPD, RESULT> Decoder<IMG, PREPD, RESULT> {
 ///
 /// It will use the following components:
 ///
-/// * prepare: BlockedMean
-/// * detect: LineScan
-/// * extract: QRExtractor
-/// * decode: QRDecoder
+/// * prepare: `BlockedMean`
+/// * detect: `LineScan`
+/// * extract: `QRExtractor`
+/// * decode: `QRDecoder`
 ///
 /// This is meant to provide a good balance between speed and accuracy
 ///
@@ -79,6 +79,7 @@ impl<IMG, PREPD, RESULT> Decoder<IMG, PREPD, RESULT> {
 ///
 /// This function will panic if the default builder fails to build,
 /// which should never happen as all components are provided.
+#[must_use]
 pub fn default_decoder() -> Decoder<DynamicImage, GrayImage, String> {
     default_builder()
         .build()
@@ -89,10 +90,10 @@ pub fn default_decoder() -> Decoder<DynamicImage, GrayImage, String> {
 ///
 /// It will use the following components:
 ///
-/// * prepare: BlockedMean
-/// * detect: LineScan
-/// * extract: QRExtractor
-/// * decode: QRDecoderWithInfo
+/// * prepare: `BlockedMean`
+/// * detect: `LineScan`
+/// * extract: `QRExtractor`
+/// * decode: `QRDecoderWithInfo`
 ///
 /// This is meant to provide a good balance between speed and accuracy
 ///
@@ -100,6 +101,7 @@ pub fn default_decoder() -> Decoder<DynamicImage, GrayImage, String> {
 ///
 /// This function will panic if the default builder fails to build,
 /// which should never happen as all components are provided.
+#[must_use]
 pub fn default_decoder_with_info() -> Decoder<DynamicImage, GrayImage, (String, QRInfo)> {
     default_builder_with_info()
         .build()
@@ -179,16 +181,17 @@ impl<IMG, PREPD, RESULT> DecoderBuilder<IMG, PREPD, RESULT> {
     }
 }
 
-/// Create a default DecoderBuilder
+/// Create a default `DecoderBuilder`
 ///
 /// It will use the following components:
 ///
-/// * prepare: BlockedMean
-/// * locate: LineScan
-/// * extract: QRExtractor
-/// * decode: QRDecoder
+/// * prepare: `BlockedMean`
+/// * locate: `LineScan`
+/// * extract: `QRExtractor`
+/// * decode: `QRDecoder`
 ///
 /// The builder can then be customised before creating the Decoder
+#[must_use]
 pub fn default_builder() -> DecoderBuilder<DynamicImage, GrayImage, String> {
     let mut db = DecoderBuilder::new();
 
@@ -199,16 +202,17 @@ pub fn default_builder() -> DecoderBuilder<DynamicImage, GrayImage, String> {
     db
 }
 
-/// Create a default DecoderBuilder that also returns information about the decoded QR Code
+/// Create a default `DecoderBuilder` that also returns information about the decoded QR Code
 ///
 /// It will use the following components:
 ///
-/// * prepare: BlockedMean
-/// * locate: LineScan
-/// * extract: QRExtractor
-/// * decode: QRDecoderWithInfo
+/// * prepare: `BlockedMean`
+/// * locate: `LineScan`
+/// * extract: `QRExtractor`
+/// * decode: `QRDecoderWithInfo`
 ///
 /// The builder can then be customised before creating the Decoder
+#[must_use]
 pub fn default_builder_with_info() -> DecoderBuilder<DynamicImage, GrayImage, (String, QRInfo)> {
     let mut db = DecoderBuilder::new();
 

--- a/src/extract/qr/mod.rs
+++ b/src/extract/qr/mod.rs
@@ -45,7 +45,7 @@ impl Extract<GrayImage, QRLocation, QRData, QRError> for QRExtractor {
         let mut data = vec![];
 
         #[cfg(feature = "debug-images")]
-        let mut img = DynamicImage::ImageLuma8(prepared.clone()).to_rgb();
+        let mut img = DynamicImage::ImageLuma8(prepared.clone()).to_rgb8();
 
         let mut dy = p.dy - 3.0 * p.ddy;
         let mut dx = p.dx - 3.0 * p.ddx;
@@ -83,14 +83,14 @@ impl Extract<GrayImage, QRLocation, QRData, QRError> for QRExtractor {
             tmp.push("bardecoder-debug-images");
             tmp.push("extract");
 
-            if let Ok(_) = create_dir_all(tmp.clone()) {
+            if create_dir_all(tmp.clone()).is_ok() {
                 tmp.push(format!(
-                    "extract_start_{}_{}_dx_{}_{}_dy_{}_{}.png",
-                    start.x, start.y, dx.dx, dx.dy, dy.dx, dy.dy
+                    "extract_start_{start_x}_{start_y}_dx_{dx_x}_{dx_y}_dy_{dy_x}_{dy_y}.png",
+                    start_x = start.x, start_y = start.y, dx_x = dx.dx, dx_y = dx.dy, dy_x = dy.dx, dy_y = dy.dy
                 ));
 
-                if let Ok(_) = DynamicImage::ImageRgb8(img).save(tmp.clone()) {
-                    debug!("Debug image with data pixels saved to {:?}", tmp);
+                if DynamicImage::ImageRgb8(img).save(tmp.clone()).is_ok() {
+                    debug!("Debug image with data pixels saved to {tmp:?}");
                 }
             }
         }
@@ -198,7 +198,7 @@ fn determine_perspective(
         }
     }
 
-    debug!("LEFT X {} RIGHT X {}", left_x, right_x);
+    debug!("LEFT X {left_x} RIGHT X {right_x}");
     est_alignment.x = (f64::from(left_x) + f64::from(right_x)) / 2.0;
 
     let al_x = est_alignment.x.round() as u32;
@@ -220,12 +220,12 @@ fn determine_perspective(
         }
     }
 
-    debug!("TOP Y {} BOTTOM Y {}", top_y, bottom_y);
+    debug!("TOP Y {top_y} BOTTOM Y {bottom_y}");
     est_alignment.y = (f64::from(top_y) + f64::from(bottom_y)) / 2.0;
 
     #[cfg(feature = "debug-images")]
     {
-        let mut img = DynamicImage::ImageLuma8(prepared.clone()).to_rgb();
+        let mut img = DynamicImage::ImageLuma8(prepared.clone()).to_rgb8();
 
         let x_start = max(0, (est_alignment.x - 2.5 * loc.module_size) as u32);
         let x_end = min(
@@ -251,11 +251,11 @@ fn determine_perspective(
         let mut tmp = temp_dir();
         tmp.push("bardecoder-debug-images");
 
-        if let Ok(_) = create_dir_all(tmp.clone()) {
+        if create_dir_all(tmp.clone()).is_ok() {
             tmp.push("alignment.png");
 
-            if let Ok(_) = DynamicImage::ImageRgb8(img).save(tmp.clone()) {
-                debug!("Debug image with data pixels saved to {:?}", tmp);
+            if DynamicImage::ImageRgb8(img).save(tmp.clone()).is_ok() {
+                debug!("Debug image with data pixels saved to {tmp:?}");
             }
         }
     }
@@ -265,11 +265,11 @@ fn determine_perspective(
         y: (loc.bottom_left + f64::from(size - 10) * dx - 3.0 * dy).y,
     };
 
-    debug!("ORIG EST {:?}, NEW EST {:?}", orig_estimate, est_alignment);
+    debug!("ORIG EST {orig_estimate:?}, NEW EST {est_alignment:?}");
 
     let mut delta = est_alignment - orig_estimate;
 
-    debug!("DELTA {:?}", delta);
+    debug!("DELTA {delta:?}");
 
     delta = delta / f64::from((size - 10) * (size - 10));
 
@@ -286,7 +286,7 @@ fn is_alignment(prepared: &GrayImage, p: Point, dx: Delta, dy: Delta, scale: f64
 
     #[cfg(feature = "debug-images")]
     {
-        let mut img = DynamicImage::ImageLuma8(prepared.clone()).to_rgb();
+        let mut img = DynamicImage::ImageLuma8(prepared.clone()).to_rgb8();
 
         for i in -2..3 {
             for j in -2..3 {
@@ -303,14 +303,14 @@ fn is_alignment(prepared: &GrayImage, p: Point, dx: Delta, dy: Delta, scale: f64
         tmp.push("bardecoder-debug-images");
         tmp.push("alignment");
 
-        if let Ok(_) = create_dir_all(tmp.clone()) {
+        if create_dir_all(tmp.clone()).is_ok() {
             tmp.push(format!(
-                "alignment_p_{}_{}_dx_{}_{}_dy_{}_{}.png",
-                p.x, p.y, dx.dx, dx.dy, dy.dx, dy.dy
+                "alignment_p_{p_x}_{p_y}_dx_{dx_x}_{dx_y}_dy_{dy_x}_{dy_y}.png",
+                p_x = p.x, p_y = p.y, dx_x = dx.dx, dx_y = dx.dy, dy_x = dy.dx, dy_y = dy.dy
             ));
 
-            if let Ok(_) = DynamicImage::ImageRgb8(img).save(tmp.clone()) {
-                debug!("Debug image with data pixels saved to {:?}", tmp);
+            if DynamicImage::ImageRgb8(img).save(tmp.clone()).is_ok() {
+                debug!("Debug image with data pixels saved to {tmp:?}");
             }
         }
     }

--- a/src/util/chomp.rs
+++ b/src/util/chomp.rs
@@ -76,7 +76,7 @@ impl Chomp {
     /// If requesting fewer than 8 bits, the result will be in the least significant bits of the u8
     pub fn chomp(&mut self, nr_bits: u8) -> Option<u8> {
         let bit_count = BitCount(nr_bits as usize);
-        if nr_bits < 1 || nr_bits > 8 || bit_count > self.bits_left {
+        if !(1..=8).contains(&nr_bits) || bit_count > self.bits_left {
             return None;
         }
 

--- a/src/util/qr.rs
+++ b/src/util/qr.rs
@@ -18,8 +18,8 @@ impl From<FromUtf8Error> for QRError {
     fn from(error: FromUtf8Error) -> Self {
         QRError {
             msg: format!(
-                "Unable to convert result to UTF-8, raw bytes: {:?}",
-                error.into_bytes()
+                "Unable to convert result to UTF-8, raw bytes: {bytes:?}",
+                bytes = error.into_bytes()
             ),
         }
     }


### PR DESCRIPTION
## Summary
- Applied comprehensive clippy fixes to improve code quality and idiomaticity
- Fixed all fixable clippy warnings from `cargo clippy --all-targets --all-features -- -W clippy::all -W clippy::pedantic`
- All tests pass successfully (20/20 lib tests, 14/14 integration tests, 6/6 doc tests)

## Changes Made

### Fixed Critical Issues
- ✅ Replaced deprecated `to_rgb()` calls with `to_rgb8()` (4 occurrences)
- ✅ Fixed empty line after doc comment in `decode/mod.rs:39`

### Code Quality Improvements
- ✅ Updated all format strings to use inline variables (30+ occurrences)
  - Example: `format!("Unknown version {}", version)` → `format!("Unknown version {version}")`
- ✅ Added backticks to code items in documentation (15+ items)
  - Example: `DecoderBuilder` → `` `DecoderBuilder` ``
- ✅ Replaced manual Option pattern with idiomatic `or_else()` chain in `linescan.rs`
- ✅ Replaced manual range check with `range.contains()` in `chomp.rs`
- ✅ Merged duplicate match arms in `blocks.rs` (5 duplicates merged)
- ✅ Removed needless borrow in `correct.rs`
- ✅ Fixed unnecessary type casts
- ✅ Added `#[must_use]` attributes to public functions
- ✅ Fixed redundant pattern matching with `is_ok()`
- ✅ Moved test module to end of file in `galois.rs`

### Files Modified
- `src/decode/mod.rs` - Fixed doc comment formatting
- `src/decode/qr/blocks.rs` - Merged duplicate match arms, fixed format strings
- `src/decode/qr/correct.rs` - Removed needless borrow, fixed casts, format strings
- `src/decode/qr/data.rs` - Fixed all format strings to use inline variables
- `src/decode/qr/decoder.rs` - Fixed format strings
- `src/decode/qr/format.rs` - Fixed format strings
- `src/decode/qr/galois.rs` - Moved test module to end
- `src/decode/qr/mod.rs` - Fixed format strings
- `src/decoder.rs` - Added backticks to docs, added `#[must_use]` attributes
- `src/detect/linescan.rs` - Fixed manual Option pattern, format strings, borrows
- `src/extract/qr/mod.rs` - Fixed deprecated `to_rgb()`, format strings, pattern matching
- `src/util/chomp.rs` - Fixed manual range contains
- `src/util/qr.rs` - Fixed format string

## Test Results
```
test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Remaining Warnings
The only remaining warnings are `non_local_definitions` from the `failure_derive` crate's derive macros. These are external dependency issues that cannot be fixed in our code and would require either updating the dependency or migrating to a different error handling approach.

## Impact
- ✅ No behavioral changes - all existing functionality preserved
- ✅ More idiomatic Rust code
- ✅ Better documentation formatting
- ✅ Improved maintainability
- ✅ Follows Rust best practices

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>